### PR TITLE
Add a longer retry backoff for free OpenAI rate limit

### DIFF
--- a/convex/lib/openai.ts
+++ b/convex/lib/openai.ts
@@ -101,7 +101,7 @@ export async function fetchEmbedding(text: string) {
 }
 
 // Retry after this much time, based on the retry number.
-const RETRY_BACKOFF = [1000, 10_000]; // In ms
+const RETRY_BACKOFF = [1000, 10_000, 20_000]; // In ms
 const RETRY_JITTER = 100; // In ms
 type RetryError = { retry: boolean; error: any };
 


### PR DESCRIPTION
Fixes error in `init.ts` when using an OpenAI free tier account (3 req/min rate limit)