### PR TITLE
Game engine responsiveness tweaks

### DIFF
--- a/src/components/PixiGame.tsx
+++ b/src/components/PixiGame.tsx
@@ -28,6 +28,8 @@ export const PixiGame = (props: {
 
   const humanPlayerId = useQuery(api.world.userStatus, { worldId: props.worldId }) ?? null;
   const players = useQuery(api.world.activePlayers, { worldId: props.worldId }) ?? [];
+  const playerLocations =
+    useQuery(api.world.activePlayerLocations, { worldId: props.worldId }) ?? {};
   const moveTo = useSendInput(props.worldId, 'moveTo');
 
   // Interaction for clicking on the world to navigate.
@@ -104,6 +106,7 @@ export const PixiGame = (props: {
         <Player
           key={`player-${p._id}`}
           player={p}
+          location={playerLocations[p._id]}
           isViewer={p._id === humanPlayerId}
           onClick={props.setSelectedElement}
           historicalTime={props.historicalTime}

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -7,7 +7,6 @@ import { useHistoricalValue } from '../hooks/useHistoricalValue.ts';
 import { useQuery } from 'convex/react';
 import { api } from '../../convex/_generated/api';
 import { PlayerMetadata } from '../../convex/world.ts';
-import { DebugPath } from './DebugPath.tsx';
 
 export type SelectElement = (element?: { kind: 'player'; id: Id<'players'> }) => void;
 
@@ -16,17 +15,19 @@ const logged = new Set<string>();
 export const Player = ({
   isViewer,
   player,
+  location,
   onClick,
   historicalTime,
 }: {
   isViewer: boolean;
   player: PlayerMetadata;
+  location: Doc<'locations'>;
   onClick: SelectElement;
   historicalTime?: number;
 }) => {
   const world = useQuery(api.world.defaultWorld);
   const character = characters.find((c) => c.name === player.character);
-  const location = useHistoricalValue<'locations'>(historicalTime, player.location);
+  const historicalLocation = useHistoricalValue<'locations'>(historicalTime, location);
   if (!character) {
     if (!logged.has(player.character)) {
       logged.add(player.character);
@@ -37,17 +38,17 @@ export const Player = ({
   if (!world) {
     return;
   }
-  if (!location) {
+  if (!historicalLocation) {
     return;
   }
   const tileDim = world.map.tileDim;
   return (
     <>
       <Character
-        x={location.x * tileDim + tileDim / 2}
-        y={location.y * tileDim + tileDim / 2}
-        orientation={orientationDegrees({ dx: location.dx, dy: location.dy })}
-        isMoving={location.velocity > 0}
+        x={historicalLocation.x * tileDim + tileDim / 2}
+        y={historicalLocation.y * tileDim + tileDim / 2}
+        orientation={orientationDegrees({ dx: historicalLocation.dx, dy: historicalLocation.dy })}
+        isMoving={historicalLocation.velocity > 0}
         isThinking={player.isThinking}
         isSpeaking={player.isSpeaking}
         isViewer={isViewer}

--- a/src/hooks/useHistoricalTime.ts
+++ b/src/hooks/useHistoricalTime.ts
@@ -8,7 +8,6 @@ export function useHistoricalTime(worldId?: Id<'worlds'>) {
   const timeManager = useRef(new HistoricalTimeManager());
   const rafRef = useRef<number>();
   const [historicalTime, setHistoricalTime] = useState<number | undefined>(undefined);
-  const [bufferHealth, setBufferHealth] = useState(0);
   if (engineStatus) {
     timeManager.current.receive(engineStatus);
   }
@@ -16,7 +15,6 @@ export function useHistoricalTime(worldId?: Id<'worlds'>) {
     // We don't need sub-millisecond precision for interpolation, so just use `Date.now()`.
     const now = Date.now();
     setHistoricalTime(timeManager.current.historicalServerTime(now));
-    setBufferHealth(timeManager.current.bufferHealth());
     rafRef.current = requestAnimationFrame(updateTime);
   };
   useEffect(() => {
@@ -143,6 +141,6 @@ export class HistoricalTimeManager {
   }
 }
 
-const MAX_SERVER_BUFFER_AGE = 1250;
-const SOFT_MAX_SERVER_BUFFER_AGE = 1000;
-const SOFT_MIN_SERVER_BUFFER_AGE = 100;
+const MAX_SERVER_BUFFER_AGE = 1500;
+const SOFT_MAX_SERVER_BUFFER_AGE = 1250;
+const SOFT_MIN_SERVER_BUFFER_AGE = 250;


### PR DESCRIPTION
- Tweak constants for historical time to be more tolerant to server jitter: We previously only tolerated less than 100ms of server execution jitter, where this PR bumps it up to 250ms. Aiming to keep the buffer at least 250ms will help smooth out replay at the cost of additional input delay. I also think this scheduling jitter should get better with agent batching.
- Extract player locations from the activePlayers queries: I noticed that the `activePlayers` query is getting invalidated all the time (still not 100% clear why), but the location buffers, which are kind of large, change at most once a step. 
