### PR TITLE
Change agents from being poll based to event driven

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as agent_embeddingsCache from "../agent/embeddingsCache";
 import type * as agent_init from "../agent/init";
 import type * as agent_main from "../agent/main";
 import type * as agent_memory from "../agent/memory";
+import type * as agent_scheduling from "../agent/scheduling";
 import type * as constants from "../constants";
 import type * as crons from "../crons";
 import type * as engine_constants from "../engine/constants";
@@ -64,6 +65,7 @@ declare const fullApi: ApiFromModules<{
   "agent/init": typeof agent_init;
   "agent/main": typeof agent_main;
   "agent/memory": typeof agent_memory;
+  "agent/scheduling": typeof agent_scheduling;
   constants: typeof constants;
   crons: typeof crons;
   "engine/constants": typeof engine_constants;

--- a/convex/agent/init.ts
+++ b/convex/agent/init.ts
@@ -47,7 +47,7 @@ export const kickAgents = internalMutation({
       .withIndex('worldId', (q) => q.eq('worldId', args.worldId))
       .collect();
     for (const agent of agents) {
-      await wakeupAgent(ctx, agent._id, 'kick');
+      await wakeupAgent(ctx, internal.agent.main.agentRun, agent._id, 'kick');
     }
   },
 });
@@ -85,7 +85,7 @@ export const resumeAgents = internalMutation({
         continue;
       }
       const allowStopped = true;
-      await wakeupAgent(ctx, agent._id, 'resume', allowStopped);
+      await wakeupAgent(ctx, internal.agent.main.agentRun, agent._id, 'resume', allowStopped);
     }
   },
 });

--- a/convex/agent/init.ts
+++ b/convex/agent/init.ts
@@ -21,7 +21,6 @@ export const initAgent = internalMutation({
     if (!description) {
       throw new Error(`No description found for character ${args.character}`);
     }
-    const now = Date.now();
     const agentId = await ctx.db.insert('agents', {
       worldId: args.worldId,
       playerId: args.playerId,
@@ -30,7 +29,7 @@ export const initAgent = internalMutation({
       generationNumber: 0,
       state: { kind: 'running', waitingOn: [] },
     });
-    await ctx.scheduler.runAt(now, internal.agent.main.agentRun, {
+    await ctx.scheduler.runAfter(0, internal.agent.main.agentRun, {
       agentId,
       generationNumber: 0,
     });

--- a/convex/agent/init.ts
+++ b/convex/agent/init.ts
@@ -28,6 +28,7 @@ export const initAgent = internalMutation({
       identity: description.identity,
       plan: description.plan,
       generationNumber: 0,
+      inProgressInputs: [],
       state: { kind: 'scheduled' },
     });
     await ctx.scheduler.runAfter(0, internal.agent.main.agentRun, {

--- a/convex/agent/main.ts
+++ b/convex/agent/main.ts
@@ -519,9 +519,10 @@ export const scheduleNextRun = internalMutation({
       throw new Error(`Invalid agent ID: ${args.agentId}`);
     }
     if (agent.generationNumber !== args.expectedGenerationNumber) {
-      throw new Error(
+      console.debug(
         `Expected generation number ${args.expectedGenerationNumber} but got ${agent.generationNumber}`,
       );
+      return;
     }
     await wakeupAgent(ctx, internal.agent.main.agentRun, args.agentId, 'actionCompleted');
   },
@@ -717,9 +718,10 @@ export const agentWriteMessage = internalMutation({
       throw new Error(`Invalid agent ID: ${args.agentId}`);
     }
     if (agent.generationNumber !== args.generationNumber) {
-      throw new Error(
+      console.debug(
         `Expected generation number ${args.generationNumber} but got ${agent.generationNumber}`,
       );
+      return;
     }
     await writeMessage(ctx, {
       conversationId: args.conversationId,

--- a/convex/agent/main.ts
+++ b/convex/agent/main.ts
@@ -11,7 +11,6 @@ import { loadConversationState } from '../world';
 import {
   AWKWARD_CONVERSATION_TIMEOUT,
   CONVERATION_COOLDOWN,
-  INPUT_DELAY,
   INVITE_ACCEPT_PROBABILITY,
   INVITE_TIMEOUT,
   MAX_CONVERSATION_DURATION,
@@ -135,6 +134,7 @@ export class Agent {
           destination,
         });
         this.agent.inProgressInputs.push(inputId);
+        waitingOn.push({ kind: 'inputCompleted', inputId });
         waitingOn.push({ kind: 'movementCompleted' });
       }
       await this.ctx.scheduler.runAfter(0, selfInternal.agentRememberConversation, {
@@ -163,6 +163,7 @@ export class Agent {
           destination,
         });
         this.agent.inProgressInputs.push(inputId);
+        waitingOn.push({ kind: 'inputCompleted', inputId });
       }
       waitingOn.push({ kind: 'movementCompleted' });
 
@@ -268,6 +269,7 @@ export class Agent {
             conversationId: playerConversation._id,
           });
           this.agent.inProgressInputs.push(inputId);
+          waitingOn.push({ kind: 'inputCompleted', inputId });
           return waitingOn;
         }
         // Don't keep moving around if we're near enough.
@@ -301,6 +303,7 @@ export class Agent {
           destination,
         });
         this.agent.inProgressInputs.push(inputId);
+        waitingOn.push({ kind: 'inputCompleted', inputId });
         waitingOn.push({ kind: 'movementCompleted' });
         waitingOn.push({
           kind: 'conversationParticipating',

--- a/convex/agent/scheduling.ts
+++ b/convex/agent/scheduling.ts
@@ -227,10 +227,9 @@ export async function wakeupAgent(
     console.warn(`Not waking up stopped agent ${agentId}`);
     return;
   }
-  // TODO:
-  // if (agent.state.kind === "scheduled") {
-  //   return;
-  // }
+  if (agent.state.kind === 'scheduled') {
+    return;
+  }
   console.log(`Waking up agent ${agentId} (${reason})`);
   const generationNumber = agent.generationNumber + 1;
   agent.generationNumber = generationNumber;

--- a/convex/agent/scheduling.ts
+++ b/convex/agent/scheduling.ts
@@ -1,0 +1,250 @@
+import { FunctionReference } from 'convex/server';
+import { Id } from '../_generated/dataModel';
+import { MutationCtx } from '../_generated/server';
+import { assertNever } from '../util/assertNever';
+import { Agent } from './main';
+import { v, Infer } from 'convex/values';
+import { TYPING_TIMEOUT } from '../constants';
+import { conversationMember } from '../game/conversationMembers';
+
+type RunReference = FunctionReference<
+  'mutation',
+  'internal',
+  { agentId: Id<'agents'>; generationNumber: number }
+>;
+
+export async function runAgent(
+  ctx: MutationCtx,
+  runReference: RunReference,
+  agentId: Id<'agents'>,
+  generationNumber: number,
+) {
+  const agentClass = await Agent.load(ctx, agentId, generationNumber);
+  if (!agentClass) {
+    return;
+  }
+  const waitingOn = await agentClass.run();
+
+  let nextRun = null;
+  for (const event of waitingOn) {
+    const eventDeadline = deadline(event);
+    if (eventDeadline !== null) {
+      nextRun = Math.min(eventDeadline, nextRun ?? eventDeadline);
+    }
+  }
+
+  const agent = agentClass.agent;
+  agent.generationNumber = agentClass.nextGenerationNumber;
+  agent.state = { kind: 'running', waitingOn: waitingOn };
+  await ctx.db.replace(agent._id, agent);
+
+  if (nextRun) {
+    const deltaSeconds = (nextRun - Date.now()) / 1000;
+    console.debug(`Scheduling next run ${deltaSeconds.toFixed(2)} in the future.`);
+    await ctx.scheduler.runAt(nextRun, runReference, {
+      agentId,
+      generationNumber: agentClass.nextGenerationNumber,
+    });
+  }
+}
+
+export async function wakeupAgents(ctx: MutationCtx, runReference: RunReference) {
+  const agents = await ctx.db.query('agents').collect();
+  const now = Date.now();
+  for (const agent of agents) {
+    if (agent.state.kind === 'stopped') {
+      continue;
+    }
+    let wakeup: null | string = null;
+    const player = await ctx.db.get(agent.playerId);
+    if (!player) {
+      throw new Error(`Agent ${agent._id} has no player ${agent.playerId}`);
+    }
+    for (const event of agent.state.waitingOn) {
+      switch (event.kind) {
+        case 'idle':
+        case 'actionCompleted':
+        case 'conversationTooLong':
+        case 'nextConversationAttempt':
+          break;
+        case 'inputCompleted': {
+          const input = await ctx.db.get(event.inputId);
+          if (!input || input.returnValue) {
+            wakeup = event.kind;
+          }
+          break;
+        }
+        case 'movementCompleted': {
+          if (!player.pathfinding) {
+            wakeup = event.kind;
+          }
+          break;
+        }
+        case 'inConversation': {
+          const member = await conversationMember(ctx.db, agent.playerId);
+          if (member) {
+            wakeup = event.kind;
+          }
+          break;
+        }
+        case 'conversationParticipating': {
+          const member = await ctx.db
+            .query('conversationMembers')
+            .withIndex('conversationId', (q) =>
+              q.eq('conversationId', event.conversationId).eq('playerId', agent.playerId),
+            )
+            .first();
+          if (member && member.status.kind === 'participating') {
+            wakeup = event.kind;
+          }
+          break;
+        }
+        case 'conversationLeft': {
+          const member = await ctx.db
+            .query('conversationMembers')
+            .withIndex('conversationId', (q) =>
+              q.eq('conversationId', event.conversationId).eq('playerId', agent.playerId),
+            )
+            .first();
+          if (member && member.status.kind === 'left') {
+            wakeup = event.kind;
+          }
+          break;
+        }
+        case 'nobodyTyping': {
+          const indicator = await ctx.db
+            .query('typingIndicator')
+            .withIndex('conversationId', (q) => q.eq('conversationId', event.conversationId))
+            .first();
+          if (!indicator || !indicator.typing || indicator.typing.since + TYPING_TIMEOUT < now) {
+            wakeup = event.kind;
+          }
+          break;
+        }
+        case 'waitingForNewMessage': {
+          const lastMessage = await ctx.db
+            .query('messages')
+            .withIndex('conversationId', (q) => q.eq('conversationId', event.conversationId))
+            .order('desc')
+            .first();
+          const lastMessageId = lastMessage?._id ?? undefined;
+          if (event.lastMessageId !== lastMessageId) {
+            wakeup = event.kind;
+          }
+          break;
+        }
+        default: {
+          assertNever(event);
+        }
+      }
+      if (wakeup) {
+        break;
+      }
+    }
+    if (wakeup) {
+      console.log(`Waking up agent ${agent._id} for event ${wakeup}`);
+      const generationNumber = agent.generationNumber + 1;
+      agent.generationNumber = generationNumber;
+      agent.state = { kind: 'running', waitingOn: [] };
+      await ctx.db.replace(agent._id, agent);
+      await ctx.scheduler.runAfter(0, runReference, { agentId: agent._id, generationNumber });
+    }
+  }
+}
+
+export const agentWaitingOn = v.union(
+  // The agent isn't waiting on anything and is scheduled to run.
+  v.object({
+    kind: v.literal('idle'),
+    nextRun: v.number(),
+  }),
+  // The agent is waiting on an action (e.g. to remember a conversation)
+  // to complete.
+  v.object({
+    kind: v.literal('actionCompleted'),
+    timeoutDeadline: v.number(),
+  }),
+  v.object({
+    kind: v.literal('inputCompleted'),
+    inputId: v.id('inputs'),
+  }),
+  // The agent has an active pathfinding state and is waiting for it
+  // to complete.
+  v.object({
+    kind: v.literal('movementCompleted'),
+    inputId: v.optional(v.id('inputs')),
+  }),
+  // Wake up if the agent is in a conversation.
+  v.object({
+    kind: v.literal('inConversation'),
+  }),
+  // The agent is waiting on them to be participating in a conversation.
+  v.object({
+    kind: v.literal('conversationParticipating'),
+    conversationId: v.id('conversations'),
+    deadline: v.number(),
+  }),
+  // The agent is waiting them to have left the conversation.
+  v.object({
+    kind: v.literal('conversationLeft'),
+    conversationId: v.id('conversations'),
+  }),
+  // When in a conversation, the agent waits for nobody to be typing
+  // before "grabbing the lock" themselves.
+  v.object({
+    kind: v.literal('nobodyTyping'),
+    conversationId: v.id('conversations'),
+  }),
+  // The agent is waiting for the other player to say something.
+  v.object({
+    kind: v.literal('waitingForNewMessage'),
+    until: v.number(),
+    conversationId: v.id('conversations'),
+    lastMessageId: v.optional(v.id('messages')),
+  }),
+  // The agent spends at most `MAX_CONVERSATION_DURATION` in a conversation.
+  v.object({
+    kind: v.literal('conversationTooLong'),
+    deadline: v.number(),
+  }),
+  // The agent waits for `CONVERSATION_COOLDOWN` after having a conversation
+  // before trying to invite someone again.
+  v.object({
+    kind: v.literal('nextConversationAttempt'),
+    nextAttempt: v.number(),
+  }),
+);
+export type WaitingOn = Infer<typeof agentWaitingOn>;
+
+function deadline(event: WaitingOn): number | null {
+  switch (event.kind) {
+    case 'idle': {
+      return event.nextRun;
+    }
+    case 'actionCompleted': {
+      return event.timeoutDeadline;
+    }
+    case 'conversationParticipating': {
+      return event.deadline;
+    }
+    case 'waitingForNewMessage': {
+      return event.until;
+    }
+    case 'conversationTooLong': {
+      return event.deadline;
+    }
+    case 'nextConversationAttempt': {
+      return event.nextAttempt;
+    }
+    case 'inputCompleted':
+    case 'movementCompleted':
+    case 'inConversation':
+    case 'conversationLeft':
+    case 'nobodyTyping': {
+      return null;
+    }
+    default: {
+      assertNever(event);
+    }
+  }
+}

--- a/convex/agent/scheduling.ts
+++ b/convex/agent/scheduling.ts
@@ -30,7 +30,6 @@ export const agentWaitingOn = v.union(
   // to complete.
   v.object({
     kind: v.literal('movementCompleted'),
-    inputId: v.optional(v.id('inputs')),
   }),
   // Wake up if the agent is in a conversation.
   v.object({

--- a/convex/agent/schema.ts
+++ b/convex/agent/schema.ts
@@ -2,6 +2,7 @@ import { memoryTables } from './memory';
 import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 import { embeddingsCacheTables } from './embeddingsCache';
+import { agentWaitingOn } from './scheduling';
 
 const agents = v.object({
   worldId: v.id('worlds'),
@@ -12,6 +13,15 @@ const agents = v.object({
   isThinking: v.optional(v.object({ since: v.number() })),
 
   generationNumber: v.number(),
+  state: v.union(
+    v.object({
+      kind: v.literal('running'),
+      waitingOn: v.array(agentWaitingOn),
+    }),
+    v.object({
+      kind: v.literal('stopped'),
+    }),
+  ),
 });
 
 export const agentTables = {

--- a/convex/agent/schema.ts
+++ b/convex/agent/schema.ts
@@ -10,8 +10,6 @@ const agents = v.object({
   identity: v.string(),
   plan: v.string(),
 
-  isThinking: v.optional(v.object({ since: v.number() })),
-
   generationNumber: v.number(),
   state: v.union(
     v.object({
@@ -29,8 +27,16 @@ const agents = v.object({
   waitingOn: v.optional(v.array(agentWaitingOn)),
 });
 
+// Separate out this flag from `agents` since it changes a lot less
+// frequently.
+const agentIsThinking = v.object({
+  playerId: v.id('players'),
+  since: v.number(),
+});
+
 export const agentTables = {
   agents: defineTable(agents).index('playerId', ['playerId']).index('worldId', ['worldId']),
+  agentIsThinking: defineTable(agentIsThinking).index('playerId', ['playerId']),
   ...memoryTables,
   ...embeddingsCacheTables,
   ...schedulingTables,

--- a/convex/agent/schema.ts
+++ b/convex/agent/schema.ts
@@ -2,7 +2,7 @@ import { memoryTables } from './memory';
 import { defineTable } from 'convex/server';
 import { v } from 'convex/values';
 import { embeddingsCacheTables } from './embeddingsCache';
-import { agentWaitingOn } from './scheduling';
+import { agentWaitingOn, schedulingTables } from './scheduling';
 
 const agents = v.object({
   worldId: v.id('worlds'),
@@ -15,17 +15,23 @@ const agents = v.object({
   generationNumber: v.number(),
   state: v.union(
     v.object({
-      kind: v.literal('running'),
-      waitingOn: v.array(agentWaitingOn),
+      kind: v.literal('waiting'),
+      timer: v.optional(v.number()),
+    }),
+    v.object({
+      kind: v.literal('scheduled'),
     }),
     v.object({
       kind: v.literal('stopped'),
     }),
   ),
+  // Last set of events the agent was waiting on for debugging.
+  waitingOn: v.optional(v.array(agentWaitingOn)),
 });
 
 export const agentTables = {
   agents: defineTable(agents).index('playerId', ['playerId']).index('worldId', ['worldId']),
   ...memoryTables,
   ...embeddingsCacheTables,
+  ...schedulingTables,
 };

--- a/convex/agent/schema.ts
+++ b/convex/agent/schema.ts
@@ -11,6 +11,12 @@ const agents = v.object({
   plan: v.string(),
 
   generationNumber: v.number(),
+
+  // Set of in-progress inputs for the agent. The inputs in this
+  // array last across runs of the agent, unlike the per-step
+  // waits managed by the scheduling system below.
+  inProgressInputs: v.array(v.id('inputs')),
+
   state: v.union(
     v.object({
       kind: v.literal('waiting'),

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -8,5 +8,6 @@ export const STEP_INTERVAL = 1000;
 export const PATHFINDING_TIMEOUT = 60 * 1000;
 export const PATHFINDING_BACKOFF = 1000;
 export const CONVERSATION_DISTANCE = 1.3;
+export const MIDPOINT_THRESHOLD = 4;
 export const TYPING_TIMEOUT = 15 * 1000;
 export const COLLISION_THRESHOLD = 0.75;

--- a/convex/engine/game.ts
+++ b/convex/engine/game.ts
@@ -4,7 +4,7 @@ import { MutationCtx } from '../_generated/server';
 import { ENGINE_WAKEUP_THRESHOLD } from './constants';
 import { FunctionReference } from 'convex/server';
 import * as agentScheduling from '../agent/scheduling';
-import { internal } from '../_generated/api';
+import { AgentRunReference } from '../agent/scheduling';
 
 export type InputHandler<Args extends any, ReturnValue extends any> = {
   args: Validator<Args, false, any>;
@@ -27,6 +27,8 @@ export abstract class Game<Handlers extends InputHandlers> {
   abstract stepDuration: number;
   abstract maxTicksPerStep: number;
   abstract maxInputsPerStep: number;
+
+  constructor(public agentRunReference: AgentRunReference) {}
 
   abstract handleInput(
     now: number,
@@ -102,7 +104,7 @@ export abstract class Game<Handlers extends InputHandlers> {
           input.returnValue = { kind: 'error', message: e.message };
         }
         await ctx.db.replace(input._id, input);
-        await agentScheduling.wakeupInput(ctx, input);
+        await agentScheduling.wakeupInput(ctx, this.agentRunReference, input);
       }
 
       // Simulate the game forward one tick.

--- a/convex/engine/gameTable.ts
+++ b/convex/engine/gameTable.ts
@@ -7,6 +7,7 @@ export abstract class GameTable<T extends TableNames> {
   abstract db: DatabaseWriter;
 
   data: Map<Id<T>, Doc<T>> = new Map();
+  inserted: Set<Id<T>> = new Set();
   modified: Set<Id<T>> = new Set();
   deleted: Set<Id<T>> = new Set();
 
@@ -25,6 +26,7 @@ export abstract class GameTable<T extends TableNames> {
       throw new Error(`Failed to db.get() inserted row`);
     }
     this.data.set(id, withSystemFields);
+    this.inserted.add(id);
     return id;
   }
 
@@ -116,7 +118,13 @@ export abstract class GameTable<T extends TableNames> {
     this.modified.add(id);
   }
 
+  modifiedOrInsertedIds(): Set<Id<T>> {
+    return new Set([...this.modified, ...this.inserted]);
+  }
+
   async save() {
+    // NB: We insert new documents immediately, so we don't need to
+    // insert them here.
     for (const id of this.deleted) {
       await this.db.delete(id);
     }
@@ -129,6 +137,7 @@ export abstract class GameTable<T extends TableNames> {
       // generic `Doc<T>` unifies with `replace()`'s type.
       await this.db.replace(id, row as any);
     }
+    this.inserted.clear();
     this.modified.clear();
     this.deleted.clear();
   }

--- a/convex/game/aiTown.ts
+++ b/convex/game/aiTown.ts
@@ -297,9 +297,14 @@ export class AiTown extends Game<Inputs> {
   stopConversation(now: number, conversation: Doc<'conversations'>) {
     conversation.finished = now;
     const members = this.conversationMembers.filter((m) => m.conversationId === conversation._id);
-    for (const member of members) {
+    if (members.length !== 2) {
+      throw new Error(`Conversation ${conversation._id} has ${members.length} members`);
+    }
+    for (let i = 0; i < members.length; i++) {
+      const member = members[i];
+      const otherMember = members[(i + 1) % 2];
       const started = member.status.kind === 'participating' ? member.status.started : undefined;
-      member.status = { kind: 'left', started, ended: now };
+      member.status = { kind: 'left', started, ended: now, with: otherMember.playerId };
     }
   }
 
@@ -345,7 +350,7 @@ export class AiTown extends Game<Inputs> {
     if (pathfinding.state.kind === 'needsPath') {
       const route = findRoute(this, now, player, pathfinding.destination);
       if (route === null) {
-        console.log(`Failed to route to ${pathfinding.destination}`);
+        console.log(`Failed to route to ${JSON.stringify(pathfinding.destination)}`);
         delete player.pathfinding;
       } else {
         if (route.newDestination) {

--- a/convex/game/aiTown.ts
+++ b/convex/game/aiTown.ts
@@ -448,11 +448,11 @@ export class AiTown extends Game<Inputs> {
   }
 
   async save(ctx: MutationCtx): Promise<void> {
-    for (const playerId of this.players.modified) {
+    for (const playerId of this.players.modifiedOrInsertedIds()) {
       const player = this.players.data.get(playerId)!;
       await agentScheduling.wakeupPlayer(ctx, this.agentRunReference, player);
     }
-    for (const memberId of this.conversationMembers.modified) {
+    for (const memberId of this.conversationMembers.modifiedOrInsertedIds()) {
       const member = this.conversationMembers.data.get(memberId)!;
       await agentScheduling.wakeupConversationMember(ctx, this.agentRunReference, member);
     }

--- a/convex/game/conversationMembers.ts
+++ b/convex/game/conversationMembers.ts
@@ -12,11 +12,17 @@ export const conversationMembers = defineTable({
     v.object({ kind: v.literal('invited') }),
     v.object({ kind: v.literal('walkingOver') }),
     v.object({ kind: v.literal('participating'), started: v.number() }),
-    v.object({ kind: v.literal('left'), started: v.optional(v.number()), ended: v.number() }),
+    v.object({
+      kind: v.literal('left'),
+      started: v.optional(v.number()),
+      ended: v.number(),
+      with: v.id('players'),
+    }),
   ),
 })
   .index('conversationId', ['conversationId', 'playerId'])
-  .index('playerId', ['playerId', 'status.kind']);
+  .index('playerId', ['playerId', 'status.kind', 'status.ended'])
+  .index('left', ['playerId', 'status.kind', 'status.with', 'status.ended']);
 
 export class ConversationMembers extends GameTable<'conversationMembers'> {
   table = 'conversationMembers' as const;

--- a/convex/game/main.ts
+++ b/convex/game/main.ts
@@ -11,7 +11,6 @@ import { api, internal } from '../_generated/api';
 import { insertInput as gameInsertInput } from '../engine/game';
 import { InputArgs, InputNames } from './inputs';
 import { Id } from '../_generated/dataModel';
-import { wakeupAgents } from '../agent/scheduling';
 
 async function getWorldId(db: DatabaseReader, engineId: Id<'engines'>) {
   const world = await db
@@ -33,7 +32,6 @@ export const runStep = internalMutation({
     const worldId = await getWorldId(ctx.db, args.engineId);
     const game = await AiTown.load(ctx.db, worldId);
     await game.runStep(ctx, internal.game.main.runStep, args.generationNumber);
-    await wakeupAgents(ctx, internal.agent.main.agentRun);
   },
 });
 

--- a/convex/game/main.ts
+++ b/convex/game/main.ts
@@ -7,7 +7,7 @@ import {
   query,
 } from '../_generated/server';
 import { AiTown } from './aiTown';
-import { api, internal } from '../_generated/api';
+import { internal } from '../_generated/api';
 import { insertInput as gameInsertInput } from '../engine/game';
 import { InputArgs, InputNames } from './inputs';
 import { Id } from '../_generated/dataModel';
@@ -30,7 +30,7 @@ export const runStep = internalMutation({
   },
   handler: async (ctx, args): Promise<void> => {
     const worldId = await getWorldId(ctx.db, args.engineId);
-    const game = await AiTown.load(ctx.db, worldId);
+    const game = await AiTown.load(ctx.db, worldId, internal.agent.main.agentRun);
     await game.runStep(ctx, internal.game.main.runStep, args.generationNumber);
   },
 });

--- a/convex/game/main.ts
+++ b/convex/game/main.ts
@@ -11,6 +11,7 @@ import { api, internal } from '../_generated/api';
 import { insertInput as gameInsertInput } from '../engine/game';
 import { InputArgs, InputNames } from './inputs';
 import { Id } from '../_generated/dataModel';
+import { wakeupAgents } from '../agent/scheduling';
 
 async function getWorldId(db: DatabaseReader, engineId: Id<'engines'>) {
   const world = await db
@@ -32,6 +33,7 @@ export const runStep = internalMutation({
     const worldId = await getWorldId(ctx.db, args.engineId);
     const game = await AiTown.load(ctx.db, worldId);
     await game.runStep(ctx, internal.game.main.runStep, args.generationNumber);
+    await wakeupAgents(ctx, internal.agent.main.agentRun);
   },
 });
 

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -36,12 +36,7 @@ const init = mutation({
     }
     // Send inputs to create players for all of the agents.
     if (await shouldCreateAgents(ctx.db, world)) {
-      let i = 0;
       for (const agent of Descriptions) {
-        if (i > 3) {
-          break;
-        }
-        i += 1;
         const inputId = await insertInput(ctx, world._id, 'join', {
           name: agent.name,
           description: agent.identity,

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -30,12 +30,7 @@ const init = mutation({
     }
     // Send inputs to create players for all of the agents.
     if (await shouldCreateAgents(ctx.db, world)) {
-      let i = 0;
       for (const agent of Descriptions) {
-        i += 1;
-        if (i > 2) {
-          break;
-        }
         const inputId = await insertInput(ctx, world._id, 'join', {
           name: agent.name,
           description: agent.identity,

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -10,7 +10,7 @@ import {
 import { Descriptions } from '../data/characters';
 import * as firstmap from '../data/firstmap';
 import { insertInput } from './game/main';
-import { initAgent, kickAgents, stopAgents } from './agent/init';
+import { initAgent, kickAgents, resumeAgents, stopAgents } from './agent/init';
 import { Doc, Id } from './_generated/dataModel';
 import { createEngine, kickEngine, startEngine, stopEngine } from './engine/game';
 
@@ -36,7 +36,12 @@ const init = mutation({
     }
     // Send inputs to create players for all of the agents.
     if (await shouldCreateAgents(ctx.db, world)) {
+      let i = 0;
       for (const agent of Descriptions) {
+        if (i > 3) {
+          break;
+        }
+        i += 1;
         const inputId = await insertInput(ctx, world._id, 'join', {
           name: agent.name,
           description: agent.identity,
@@ -91,7 +96,7 @@ export const resume = internalMutation({
     console.log(`Resuming engine ${engine._id} for world ${world._id} (state: ${world.status})...`);
     await ctx.db.patch(world._id, { status: 'running' });
     await startEngine(ctx, internal.game.main.runStep, engine._id);
-    await kickAgents(ctx, { worldId: world._id });
+    await resumeAgents(ctx, { worldId: world._id });
   },
 });
 

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -1,17 +1,11 @@
 import { v } from 'convex/values';
-import { api, internal } from './_generated/api';
-import {
-  DatabaseReader,
-  DatabaseWriter,
-  MutationCtx,
-  internalMutation,
-  mutation,
-} from './_generated/server';
+import { internal } from './_generated/api';
+import { DatabaseReader, MutationCtx, internalMutation, mutation } from './_generated/server';
 import { Descriptions } from '../data/characters';
 import * as firstmap from '../data/firstmap';
 import { insertInput } from './game/main';
 import { initAgent, kickAgents, resumeAgents, stopAgents } from './agent/init';
-import { Doc, Id } from './_generated/dataModel';
+import { Doc } from './_generated/dataModel';
 import { createEngine, kickEngine, startEngine, stopEngine } from './engine/game';
 
 const init = mutation({
@@ -36,7 +30,12 @@ const init = mutation({
     }
     // Send inputs to create players for all of the agents.
     if (await shouldCreateAgents(ctx.db, world)) {
+      let i = 0;
       for (const agent of Descriptions) {
+        i += 1;
+        if (i > 2) {
+          break;
+        }
         const inputId = await insertInput(ctx, world._id, 'join', {
           name: agent.name,
           description: agent.identity,

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -27,6 +27,13 @@ export const listMessages = query({
 });
 
 export async function getCurrentlyTyping(db: DatabaseReader, conversationId: Id<'conversations'>) {
+  const conversation = await db.get(conversationId);
+  if (!conversation) {
+    throw new Error(`Invalid conversation ID: ${conversationId}`);
+  }
+  if (conversation.finished) {
+    return null;
+  }
   // We have at most one row per conversation in the `typingIndicator` table, so
   // we can fetch a single row to determine if someone's typing.
   const indicator = await db

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -133,7 +133,11 @@ export const writeMessage = mutation({
       .withIndex('conversationId', (q) => q.eq('conversationId', args.conversationId))
       .unique();
     if (indicator?.typing?.playerId === args.playerId) {
-      await agentScheduling.wakeupTypingIndicatorCleared(ctx, args.conversationId);
+      await agentScheduling.wakeupTypingIndicatorCleared(
+        ctx,
+        internal.agent.main.agentRun,
+        args.conversationId,
+      );
       await ctx.db.patch(indicator._id, {
         typing: undefined,
         versionNumber: indicator.versionNumber + 1,
@@ -144,7 +148,7 @@ export const writeMessage = mutation({
       author: args.playerId,
       text: args.text,
     });
-    await agentScheduling.wakeupNewMessage(ctx, args.conversationId);
+    await agentScheduling.wakeupNewMessage(ctx, internal.agent.main.agentRun, args.conversationId);
   },
 });
 
@@ -168,6 +172,10 @@ export const clearTyping = internalMutation({
       throw new Error(`No typing indicator to clear despite version number matching`);
     }
     await ctx.db.patch(indicator._id, { typing: undefined, versionNumber: args.versionNumber + 1 });
-    await agentScheduling.wakeupTypingIndicatorCleared(ctx, args.conversationId);
+    await agentScheduling.wakeupTypingIndicatorCleared(
+      ctx,
+      internal.agent.main.agentRun,
+      args.conversationId,
+    );
   },
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 import { internalMutation, mutation, query } from './_generated/server';
 import { TYPING_TIMEOUT } from './constants';
 import { internal } from './_generated/api';
+import { wakeupAgents } from './agent/scheduling';
 
 export const listMessages = query({
   args: {
@@ -129,6 +130,7 @@ export const writeMessage = mutation({
       author: args.playerId,
       text: args.text,
     });
+    await wakeupAgents(ctx, internal.agent.main.agentRun);
   },
 });
 
@@ -152,5 +154,6 @@ export const clearTyping = internalMutation({
       throw new Error(`No typing indicator to clear despite version number matching`);
     }
     await ctx.db.patch(indicator._id, { typing: undefined, versionNumber: args.versionNumber + 1 });
+    await wakeupAgents(ctx, internal.agent.main.agentRun);
   },
 });

--- a/convex/world.ts
+++ b/convex/world.ts
@@ -7,6 +7,7 @@ import { kickAgents, stopAgents } from './agent/init';
 import { Doc, Id } from './_generated/dataModel';
 import { internal } from './_generated/api';
 import { startEngine, stopEngine } from './engine/game';
+import { conversationMember } from './game/conversationMembers';
 
 export const defaultWorld = query({
   handler: async (ctx) => {
@@ -287,24 +288,7 @@ export const loadConversationState = query({
     if (!player) {
       throw new Error(`Invalid player ID: ${args.playerId}`);
     }
-    // TODO: We could combine these queries if we had `.neq()` in our index query API.
-    const invited = await ctx.db
-      .query('conversationMembers')
-      .withIndex('playerId', (q) => q.eq('playerId', player._id).eq('status.kind', 'invited'))
-      .unique();
-    const walkingOver = await ctx.db
-      .query('conversationMembers')
-      .withIndex('playerId', (q) => q.eq('playerId', player._id).eq('status.kind', 'walkingOver'))
-      .unique();
-    const participating = await ctx.db
-      .query('conversationMembers')
-      .withIndex('playerId', (q) => q.eq('playerId', player._id).eq('status.kind', 'participating'))
-      .unique();
-
-    if ([invited, walkingOver, participating].filter(Boolean).length > 1) {
-      throw new Error(`Player ${player._id} is in multiple conversations`);
-    }
-    const member = invited ?? walkingOver ?? participating;
+    const member = await conversationMember(ctx.db, player._id);
     if (!member) {
       return null;
     }

--- a/convex/world.ts
+++ b/convex/world.ts
@@ -3,7 +3,7 @@ import { internalMutation, mutation, query } from './_generated/server';
 import { characters } from '../data/characters';
 import { sendInput } from './game/main';
 import { IDLE_WORLD_TIMEOUT } from './constants';
-import { kickAgents, stopAgents } from './agent/init';
+import { kickAgents, resumeAgents, stopAgents } from './agent/init';
 import { Doc, Id } from './_generated/dataModel';
 import { internal } from './_generated/api';
 import { startEngine, stopEngine } from './engine/game';
@@ -52,7 +52,7 @@ export const heartbeatWorld = mutation({
       console.log(`Restarting inactive world ${world._id}...`);
       await ctx.db.patch(world._id, { status: 'running' });
       await startEngine(ctx, internal.game.main.runStep, engine._id);
-      await kickAgents(ctx, { worldId: world._id });
+      await resumeAgents(ctx, { worldId: world._id });
     }
   },
 });

--- a/convex/world.ts
+++ b/convex/world.ts
@@ -274,31 +274,6 @@ export const activePlayerLocations = query({
   },
 });
 
-export const activePlayerLocations = query({
-  args: {
-    worldId: v.id('worlds'),
-  },
-  handler: async (ctx, args): Promise<Record<Id<'players'>, Doc<'locations'>>> => {
-    const world = await ctx.db.get(args.worldId);
-    if (!world) {
-      throw new Error(`Invalid world ID: ${args.worldId}`);
-    }
-    const out: Record<Id<'players'>, Doc<'locations'>> = {};
-    const players = await ctx.db
-      .query('players')
-      .withIndex('active', (q) => q.eq('worldId', world._id).eq('active', true))
-      .collect();
-    for (const player of players) {
-      const location = await ctx.db.get(player.locationId);
-      if (!location) {
-        throw new Error(`Invalid location ID: ${player.locationId}`);
-      }
-      out[player._id] = location;
-    }
-    return out;
-  },
-});
-
 export type ConversationState = Doc<'conversations'> & {
   member: Doc<'conversationMembers'>;
   otherPlayerId: Id<'players'>;


### PR DESCRIPTION
(Moving https://github.com/get-convex/ai-town/pull/49 over to this repo.)

This PR changes the agents to tell the scheduling layer above what they're waiting on. Then, the scheduler can wake them up when either (1) a timer completes or (2) some data they observed changes.

https://github.com/get-convex/ai-town/assets/5784949/d7f56686-7197-47b2-843c-0431102be930

The bookkeeping here is a bit tricky, where agents can tell the scheduler that they're waiting on one of any conditions to change, and then writes elsewhere in the system need to wake up the appropriate agents. @thomasballinger this could be a good use case for a scheduler based "trigger" in the future.

I'll put up the `agentRun` batching in a separate stacked PR.