### PR TITLE
Sujayakar/agent batching

### DIFF
--- a/convex/agent/constants.ts
+++ b/convex/agent/constants.ts
@@ -28,3 +28,6 @@ export const ACTION_TIMEOUT = 60 * 1000;
 
 // Wait for at least two seconds before sending another message.
 export const MESSAGE_COOLDOWN = 2000;
+
+// Run the agent scheduler at most once every 500ms.
+export const SCHEDULER_COOLDOWN = 500;

--- a/convex/agent/main.ts
+++ b/convex/agent/main.ts
@@ -58,17 +58,6 @@ export class Agent {
     if (!player) {
       throw new Error(`Invalid player ID: ${agent.playerId}`);
     }
-    const engine = await ctx.db.get(world.engineId);
-    if (!engine) {
-      throw new Error(`Invalid engine ID: ${world.engineId}`);
-    }
-    // NB: We're just being defensive with this check, but any process (e.g. `stopInactiveWorlds`)
-    // that stops the engine should also stop the agents, bumping their generation number and
-    // causing us to hit the generation number check above first.
-    if (engine.state.kind !== 'running') {
-      console.debug(`Engine ${world.engineId} isn't running`);
-      return null;
-    }
     const location = await ctx.db.get(player.locationId);
     if (!location) {
       throw new Error(`Invalid location ID: ${player.locationId}`);

--- a/convex/agent/scheduling.ts
+++ b/convex/agent/scheduling.ts
@@ -6,7 +6,7 @@ import { v, Infer } from 'convex/values';
 import { SCHEDULER_COOLDOWN } from './constants';
 
 export type SchedulerRun = FunctionReference<
-  'action',
+  'mutation',
   'internal',
   { schedulerId: Id<'agentSchedulers'>; generationNumber: number }
 >;

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -6,7 +6,7 @@ export const TICK = 16;
 export const STEP_INTERVAL = 1000;
 
 export const PATHFINDING_TIMEOUT = 60 * 1000;
-export const PATHFINDING_BACKOFF = 1000;
+export const PATHFINDING_BACKOFF = 3000;
 export const CONVERSATION_DISTANCE = 1.3;
 export const MIDPOINT_THRESHOLD = 4;
 export const TYPING_TIMEOUT = 15 * 1000;

--- a/convex/engine/game.ts
+++ b/convex/engine/game.ts
@@ -4,7 +4,7 @@ import { MutationCtx } from '../_generated/server';
 import { ENGINE_WAKEUP_THRESHOLD } from './constants';
 import { FunctionReference } from 'convex/server';
 import * as agentScheduling from '../agent/scheduling';
-import { AgentRunReference } from '../agent/scheduling';
+import { SchedulerRun } from '../agent/scheduling';
 
 export type InputHandler<Args extends any, ReturnValue extends any> = {
   args: Validator<Args, false, any>;
@@ -28,7 +28,7 @@ export abstract class Game<Handlers extends InputHandlers> {
   abstract maxTicksPerStep: number;
   abstract maxInputsPerStep: number;
 
-  constructor(public agentRunReference: AgentRunReference) {}
+  constructor(public schedulerRun: SchedulerRun) {}
 
   abstract handleInput(
     now: number,
@@ -104,7 +104,7 @@ export abstract class Game<Handlers extends InputHandlers> {
           input.returnValue = { kind: 'error', message: e.message };
         }
         await ctx.db.replace(input._id, input);
-        await agentScheduling.wakeupInput(ctx, this.agentRunReference, input);
+        await agentScheduling.wakeupInput(ctx, this.schedulerRun, input);
       }
 
       // Simulate the game forward one tick.

--- a/convex/game/aiTown.ts
+++ b/convex/game/aiTown.ts
@@ -12,7 +12,7 @@ import { CONVERSATION_DISTANCE, PATHFINDING_BACKOFF, PATHFINDING_TIMEOUT } from 
 import { Conversations } from './conversations';
 import { ConversationMembers } from './conversationMembers';
 import * as agentScheduling from '../agent/scheduling';
-import { AgentRunReference } from '../agent/scheduling';
+import { SchedulerRun } from '../agent/scheduling';
 
 export class AiTown extends Game<Inputs> {
   tickDuration = 16;
@@ -28,16 +28,12 @@ export class AiTown extends Game<Inputs> {
     public locations: Locations,
     public conversations: Conversations,
     public conversationMembers: ConversationMembers,
-    agentRunReference: AgentRunReference,
+    schedulerRun: SchedulerRun,
   ) {
-    super(agentRunReference);
+    super(schedulerRun);
   }
 
-  static async load(
-    db: DatabaseWriter,
-    worldId: Id<'worlds'>,
-    agentRunReference: AgentRunReference,
-  ) {
+  static async load(db: DatabaseWriter, worldId: Id<'worlds'>, schedulerRun: SchedulerRun) {
     const world = await db.get(worldId);
     if (!world) {
       throw new Error(`Invalid world ID: ${worldId}`);
@@ -59,7 +55,7 @@ export class AiTown extends Game<Inputs> {
       locations,
       conversations,
       conversationMembers,
-      agentRunReference,
+      schedulerRun,
     );
   }
 
@@ -450,11 +446,11 @@ export class AiTown extends Game<Inputs> {
   async save(ctx: MutationCtx): Promise<void> {
     for (const playerId of this.players.modifiedOrInsertedIds()) {
       const player = this.players.data.get(playerId)!;
-      await agentScheduling.wakeupPlayer(ctx, this.agentRunReference, player);
+      await agentScheduling.wakeupPlayer(ctx, this.schedulerRun, player);
     }
     for (const memberId of this.conversationMembers.modifiedOrInsertedIds()) {
       const member = this.conversationMembers.data.get(memberId)!;
-      await agentScheduling.wakeupConversationMember(ctx, this.agentRunReference, member);
+      await agentScheduling.wakeupConversationMember(ctx, this.schedulerRun, member);
     }
     await this.players.save();
     await this.locations.save();

--- a/convex/game/main.ts
+++ b/convex/game/main.ts
@@ -30,7 +30,7 @@ export const runStep = internalMutation({
   },
   handler: async (ctx, args): Promise<void> => {
     const worldId = await getWorldId(ctx.db, args.engineId);
-    const game = await AiTown.load(ctx.db, worldId, internal.agent.main.agentRun);
+    const game = await AiTown.load(ctx.db, worldId, internal.agent.main.agentSchedulerRun);
     await game.runStep(ctx, internal.game.main.runStep, args.generationNumber);
   },
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -142,7 +142,7 @@ export const writeMessage = mutation({
     if (indicator?.typing?.playerId === args.playerId) {
       await agentScheduling.wakeupTypingIndicatorCleared(
         ctx,
-        internal.agent.main.agentRun,
+        internal.agent.main.agentSchedulerRun,
         args.conversationId,
       );
       await ctx.db.patch(indicator._id, {
@@ -155,7 +155,11 @@ export const writeMessage = mutation({
       author: args.playerId,
       text: args.text,
     });
-    await agentScheduling.wakeupNewMessage(ctx, internal.agent.main.agentRun, args.conversationId);
+    await agentScheduling.wakeupNewMessage(
+      ctx,
+      internal.agent.main.agentSchedulerRun,
+      args.conversationId,
+    );
   },
 });
 
@@ -181,7 +185,7 @@ export const clearTyping = internalMutation({
     await ctx.db.patch(indicator._id, { typing: undefined, versionNumber: args.versionNumber + 1 });
     await agentScheduling.wakeupTypingIndicatorCleared(
       ctx,
-      internal.agent.main.agentRun,
+      internal.agent.main.agentSchedulerRun,
       args.conversationId,
     );
   },


### PR DESCRIPTION
This PR implements agent batching, where we run the agents in one big mutation to decrease the number of functions run per second.

This works pretty well for four agents, but I'm finding it hard to get this to scale to eight. The main problem is that batching everything into one big transaction makes it (1) slow and (2) have a large read set. This makes the agent transaction race with the engine and persistently fail with OCC retries. 

I haven't seen it fully exhaust OCC retries yet, but there's long scheduling delay between the mutation getting scheduled and it completing, which makes the agents unresponsive.

Some options I'm going to explore:
1. Try to make the "one mutation loop per agent" approach work better by decreasing the number of functions run per second. Currently, I believe this approach is overwhelming our UDF layer, causing it to go into LIFO.
2. Continue to batch the agents into one big mutation but try to simulate snapshot isolation by doing all data fetching in a query. I have this working, but it's annoying to handle transient failures for the scheduled action.
3. Move the agent behavior into the game engine. This makes the agent less modular but will likely solve all our problems since it's now "on the main thread" and not reading from data the game engine's writing.