### PR TITLE
Make agent and engine scheduling more efficient by not wasting preempted runs

### DIFF
--- a/convex/agent/constants.ts
+++ b/convex/agent/constants.ts
@@ -28,3 +28,6 @@ export const ACTION_TIMEOUT = 60 * 1000;
 
 // Wait for at least two seconds before sending another message.
 export const MESSAGE_COOLDOWN = 2000;
+
+// Don't run a turn of the agent more than once a second.
+export const AGENT_WAKEUP_THRESHOLD = 1000;

--- a/convex/agent/embeddingsCache.ts
+++ b/convex/agent/embeddingsCache.ts
@@ -3,7 +3,6 @@ import { v } from 'convex/values';
 import { ActionCtx, internalMutation, internalQuery } from '../_generated/server';
 import { internal } from '../_generated/api';
 import * as openai from '../util/openai';
-import { Id } from '../_generated/dataModel';
 
 const selfInternal = internal.agent.embeddingsCache;
 

--- a/convex/agent/main.ts
+++ b/convex/agent/main.ts
@@ -74,17 +74,6 @@ export class Agent {
     if (!player) {
       throw new Error(`Invalid player ID: ${agent.playerId}`);
     }
-    const engine = await ctx.db.get(world.engineId);
-    if (!engine) {
-      throw new Error(`Invalid engine ID: ${world.engineId}`);
-    }
-    // NB: We're just being defensive with this check, but any process (e.g. `stopInactiveWorlds`)
-    // that stops the engine should also stop the agents, bumping their generation number and
-    // causing us to hit the generation number check above first.
-    if (engine.state.kind !== 'running') {
-      console.debug(`Engine ${world.engineId} isn't running`);
-      return null;
-    }
     const location = await ctx.db.get(player.locationId);
     if (!location) {
       throw new Error(`Invalid location ID: ${player.locationId}`);

--- a/convex/agent/schema.ts
+++ b/convex/agent/schema.ts
@@ -16,6 +16,12 @@ const agents = v.object({
   // array last across runs of the agent, unlike the per-step
   // waits managed by the scheduling system below.
   inProgressInputs: v.array(v.id('inputs')),
+  inProgressAction: v.optional(
+    v.object({
+      name: v.string(),
+      started: v.number(),
+    }),
+  ),
 
   state: v.union(
     v.object({

--- a/convex/agent/schema.ts
+++ b/convex/agent/schema.ts
@@ -19,24 +19,19 @@ const agents = v.object({
   inProgressAction: v.optional(
     v.object({
       name: v.string(),
+      uuid: v.string(),
       started: v.number(),
     }),
   ),
+  running: v.boolean(),
 
-  state: v.union(
-    v.object({
-      kind: v.literal('waiting'),
-      timer: v.optional(v.number()),
-    }),
-    v.object({
-      kind: v.literal('scheduled'),
-    }),
-    v.object({
-      kind: v.literal('stopped'),
-    }),
-  ),
   // Last set of events the agent was waiting on for debugging.
   waitingOn: v.optional(v.array(agentWaitingOn)),
+});
+
+const agentScheduledRuns = v.object({
+  agentId: v.id('agents'),
+  runTimestamp: v.number(),
 });
 
 // Separate out this flag from `agents` since it changes a lot less
@@ -48,6 +43,7 @@ const agentIsThinking = v.object({
 
 export const agentTables = {
   agents: defineTable(agents).index('playerId', ['playerId']).index('worldId', ['worldId']),
+  agentScheduledRuns: defineTable(agentScheduledRuns).index('agentId', ['agentId', 'runTimestamp']),
   agentIsThinking: defineTable(agentIsThinking).index('playerId', ['playerId']),
   ...memoryTables,
   ...embeddingsCacheTables,

--- a/convex/engine/schema.ts
+++ b/convex/engine/schema.ts
@@ -41,15 +41,7 @@ const engines = v.object({
   // How far has the engine processed in the input queue?
   processedInputNumber: v.optional(v.number()),
 
-  state: v.union(
-    v.object({
-      kind: v.literal('running'),
-      nextRun: v.number(),
-    }),
-    v.object({
-      kind: v.literal('stopped'),
-    }),
-  ),
+  running: v.boolean(),
 
   // Monotonically increasing counter that allows inputs to restart the engine
   // when it's sleeping. In particular, every scheduled run of the engine

--- a/convex/engine/schema.ts
+++ b/convex/engine/schema.ts
@@ -59,7 +59,16 @@ const engines = v.object({
   generationNumber: v.number(),
 });
 
+const engineScheduledRuns = v.object({
+  engineId: v.id('engines'),
+  runTimestamp: v.number(),
+});
+
 export const engineTables = {
   inputs: defineTable(inputs).index('byInputNumber', ['engineId', 'number']),
   engines: defineTable(engines),
+  engineScheduledRuns: defineTable(engineScheduledRuns).index('engineId', [
+    'engineId',
+    'runTimestamp',
+  ]),
 };

--- a/convex/game/main.ts
+++ b/convex/game/main.ts
@@ -26,12 +26,12 @@ async function getWorldId(db: DatabaseReader, engineId: Id<'engines'>) {
 export const runStep = internalMutation({
   args: {
     engineId: v.id('engines'),
-    generationNumber: v.number(),
+    runId: v.id('engineScheduledRuns'),
   },
   handler: async (ctx, args): Promise<void> => {
     const worldId = await getWorldId(ctx.db, args.engineId);
     const game = await AiTown.load(ctx.db, worldId, internal.agent.main.agentRun);
-    await game.runStep(ctx, internal.game.main.runStep, args.generationNumber);
+    await game.runStep(ctx, internal.game.main.runStep, args.runId);
   },
 });
 

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -35,7 +35,7 @@ const init = mutation({
     if (await shouldCreateAgents(ctx.db, world)) {
       let numCreated = 0;
       for (const agent of Descriptions) {
-        if (args.numAgents && numCreated >= args.numAgents) {
+        if (args.numAgents !== undefined && numCreated >= args.numAgents) {
           break;
         }
         const inputId = await insertInput(ctx, world._id, 'join', {

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -67,7 +67,7 @@ export const stop = internalMutation({
   handler: async (ctx) => {
     const { world, engine } = await getDefaultWorld(ctx.db);
     if (world.status === 'inactive' || world.status === 'stoppedByDeveloper') {
-      if (engine.state.kind !== 'stopped') {
+      if (engine.running) {
         throw new Error(`Engine ${engine._id} isn't stopped?`);
       }
       console.debug(`World ${world._id} is already inactive`);
@@ -84,7 +84,7 @@ export const resume = internalMutation({
   handler: async (ctx) => {
     const { world, engine } = await getDefaultWorld(ctx.db);
     if (world.status === 'running') {
-      if (engine.state.kind !== 'running') {
+      if (!engine.running) {
         throw new Error(`Engine ${engine._id} isn't running?`);
       }
       console.debug(`World ${world._id} is already running`);
@@ -100,7 +100,7 @@ export const resume = internalMutation({
 export const archive = internalMutation({
   handler: async (ctx) => {
     const { world, engine } = await getDefaultWorld(ctx.db);
-    if (engine.state.kind === 'running') {
+    if (engine.running) {
       throw new Error(`Engine ${engine._id} is still running!`);
     }
     console.log(`Archiving world ${world._id}...`);

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -131,9 +131,10 @@ export const writeMessage = mutation({
       )
       .unique();
     if (!member || member.status.kind !== 'participating') {
-      throw new Error(
+      console.debug(
         `Player ${args.playerId} is not participating in conversation ${args.conversationId}`,
       );
+      return;
     }
     const indicator = await ctx.db
       .query('typingIndicator')

--- a/convex/world.ts
+++ b/convex/world.ts
@@ -86,7 +86,13 @@ export const engineStatus = query({
     if (!engine) {
       throw new Error(`Invalid engine ID: ${world.engineId}`);
     }
-    return engine;
+    const nextRunDoc = await ctx.db
+      .query('engineScheduledRuns')
+      .withIndex('engineId', (q) => q.eq('engineId', engine._id))
+      .order('asc')
+      .first();
+    const nextRun = nextRunDoc?.runTimestamp;
+    return { nextRun, ...engine };
   },
 });
 

--- a/src/components/DebugTimeManager.tsx
+++ b/src/components/DebugTimeManager.tsx
@@ -115,9 +115,9 @@ export function DebugTimeManager(props: {
   let statusNode: React.ReactNode | null = null;
   if (timeManager.latestEngineStatus) {
     const status = timeManager.latestEngineStatus;
-    let statusMsg = status.state.kind;
-    if (status.state.kind === 'running') {
-      statusMsg += ` in ${toSeconds(status.state.nextRun - Date.now())}s`;
+    let statusMsg = status.running ? 'Running' : 'Stopped';
+    if (status.nextRun) {
+      statusMsg += ` in ${toSeconds(status.nextRun - Date.now())}s`;
     }
     statusNode = (
       <div style={{ fontSize: '12px', paddingTop: '8px' }}>

--- a/src/components/DebugTimeManager.tsx
+++ b/src/components/DebugTimeManager.tsx
@@ -116,7 +116,7 @@ export function DebugTimeManager(props: {
   if (timeManager.latestEngineStatus) {
     const status = timeManager.latestEngineStatus;
     let statusMsg = status.running ? 'Running' : 'Stopped';
-    if (status.nextRun) {
+    if (status.running && status.nextRun) {
       statusMsg += ` in ${toSeconds(status.nextRun - Date.now())}s`;
     }
     statusNode = (

--- a/src/hooks/useHistoricalTime.ts
+++ b/src/hooks/useHistoricalTime.ts
@@ -35,9 +35,9 @@ export class HistoricalTimeManager {
   prevServerTs?: number;
   totalDuration: number = 0;
 
-  latestEngineStatus?: Doc<'engines'>;
+  latestEngineStatus?: Doc<'engines'> & { nextRun?: number };
 
-  receive(engineStatus: Doc<'engines'>) {
+  receive(engineStatus: Doc<'engines'> & { nextRun?: number }) {
     this.latestEngineStatus = engineStatus;
     if (!engineStatus.currentTime || !engineStatus.lastStepTs) {
       return;


### PR DESCRIPTION
Until we can cancel runs in the scheduler, our current approach of scheduling a future predicated on a generation number and then canceling it by bumping the generation number is wasteful.

For large numbers of agents, this approach clogs up the scheduler and UDF execution queue with a bunch of runs that return immediately on the generation number mismatch. 

This PR keeps generation numbers but only uses them _within_ the mutation to force an OCC error whenever mutation runs aren't serialized. Then, we do some additional bookkeeping to schedule 

This approach still has a lot of contention between the engine state and agent state, which I think is unavoidable until we can subscribe on read sets. I'm going to explore pulling more of agents back into the game engine next.