### PR TITLE
Bring back freeze button

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ npm run dev:backend
 See package.json for details, but dev:backend runs `npx convex dev`
 
 **Note**: The simulation will pause after 5 minutes if the window is idle.
-Loading the page will unpause it. If you want to run the world without the
+Loading the page will unpause it.
+You can also manually freeze & unfreeze the world with a button in the UI.
+If you want to run the world without the
 browser, you can comment-out the "stop inactive worlds" cron in `convex/crons.ts`.
 
 ### Various commands to run / test / debug
@@ -124,19 +126,19 @@ This will stop running the engine and agents. You can still run queries and
 run functions to debug.
 
 ```bash
-npx convex run --no-push init:stop
+npx convex run --no-push testing:stop
 ```
 
 **To restart the back end after stopping it**
 
 ```bash
-npx convex run init:resume
+npx convex run testing:resume
 ```
 
 **To kick the engine in case the game engine or agents aren't running**
 
 ```bash
-npx convex run init:kick
+npx convex run testing:kick
 ```
 
 **To archive the world**
@@ -144,7 +146,7 @@ npx convex run init:kick
 If you'd like to reset the world and start from scratch, you can archive the current world:
 
 ```bash
-npx convex run init:archive
+npx convex run testing:archive
 ```
 
 Then, you can still look at the world's data in the dashboard, but the engine and agents will

--- a/convex/testing.ts
+++ b/convex/testing.ts
@@ -1,8 +1,10 @@
 import { TableNames } from './_generated/dataModel';
 import { internal } from './_generated/api';
-import { internalMutation } from './_generated/server';
+import { DatabaseReader, internalMutation, mutation, query } from './_generated/server';
 import { v } from 'convex/values';
 import schema from './schema';
+import { kickAgents, stopAgents } from './agent/init';
+import { kickEngine, startEngine, stopEngine } from './engine/game';
 
 const DELETE_BATCH_SIZE = 64;
 
@@ -40,3 +42,78 @@ export const deletePage = internalMutation({
     }
   },
 });
+
+export const kick = internalMutation({
+  handler: async (ctx) => {
+    const { world, engine } = await getDefaultWorld(ctx.db);
+    await kickEngine(ctx, internal.game.main.runStep, engine._id);
+    await kickAgents(ctx, { worldId: world._id });
+  },
+});
+
+export const stopAllowed = query({
+  handler: async () => {
+    return !process.env.STOP_NOT_ALLOWED;
+  },
+});
+
+export const stop = mutation({
+  handler: async (ctx) => {
+    if (process.env.STOP_NOT_ALLOWED) throw new Error('Stop not allowed');
+    const { world, engine } = await getDefaultWorld(ctx.db);
+    if (world.status === 'inactive' || world.status === 'stoppedByDeveloper') {
+      if (engine.state.kind !== 'stopped') {
+        throw new Error(`Engine ${engine._id} isn't stopped?`);
+      }
+      console.debug(`World ${world._id} is already inactive`);
+      return;
+    }
+    console.log(`Stopping engine ${engine._id}...`);
+    await ctx.db.patch(world._id, { status: 'stoppedByDeveloper' });
+    await stopEngine(ctx, engine._id);
+    await stopAgents(ctx, { worldId: world._id });
+  },
+});
+
+export const resume = mutation({
+  handler: async (ctx) => {
+    const { world, engine } = await getDefaultWorld(ctx.db);
+    if (world.status === 'running') {
+      if (engine.state.kind !== 'running') {
+        throw new Error(`Engine ${engine._id} isn't running?`);
+      }
+      console.debug(`World ${world._id} is already running`);
+      return;
+    }
+    console.log(`Resuming engine ${engine._id} for world ${world._id} (state: ${world.status})...`);
+    await ctx.db.patch(world._id, { status: 'running' });
+    await startEngine(ctx, internal.game.main.runStep, engine._id);
+    await kickAgents(ctx, { worldId: world._id });
+  },
+});
+
+export const archive = internalMutation({
+  handler: async (ctx) => {
+    const { world, engine } = await getDefaultWorld(ctx.db);
+    if (engine.state.kind === 'running') {
+      throw new Error(`Engine ${engine._id} is still running!`);
+    }
+    console.log(`Archiving world ${world._id}...`);
+    await ctx.db.patch(world._id, { isDefault: false });
+  },
+});
+
+async function getDefaultWorld(db: DatabaseReader) {
+  const world = await db
+    .query('worlds')
+    .filter((q) => q.eq(q.field('isDefault'), true))
+    .first();
+  if (!world) {
+    throw new Error('No default world found');
+  }
+  const engine = await db.get(world.engineId);
+  if (!engine) {
+    throw new Error(`Engine ${world.engineId} not found`);
+  }
+  return { world, engine };
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import ReactModal from 'react-modal';
 import MusicButton from './components/buttons/MusicButton.tsx';
 import Button from './components/buttons/Button.tsx';
 import InteractButton from './components/buttons/InteractButton.tsx';
+import FreezeButton from './components/FreezeButton.tsx';
 
 export default function Home() {
   const [helpModalOpen, setHelpModalOpen] = useState(false);
@@ -85,6 +86,7 @@ export default function Home() {
 
         <footer className="absolute bottom-0 left-0 w-full flex items-center mt-4 gap-3 p-6 flex-wrap pointer-events-none">
           <div className="flex gap-4 flex-grow pointer-events-none">
+            <FreezeButton />
             <MusicButton />
             <Button href="https://github.com/get-convex/ai-town" imgUrl={starImg}>
               Star

--- a/src/components/FreezeButton.tsx
+++ b/src/components/FreezeButton.tsx
@@ -1,4 +1,3 @@
-'use client';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '../../convex/_generated/api';
 import Button from './buttons/Button';

--- a/src/components/FreezeButton.tsx
+++ b/src/components/FreezeButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '../../convex/_generated/api';
+import Button from './buttons/Button';
+
+export default function FreezeButton() {
+  const stopAllowed = useQuery(api.testing.stopAllowed) ?? false;
+  const defaultWorld = useQuery(api.world.defaultWorld);
+
+  const frozen = defaultWorld?.status === 'stoppedByDeveloper';
+
+  const unfreeze = useMutation(api.testing.resume);
+  const freeze = useMutation(api.testing.stop);
+
+  const flipSwitch = async () => {
+    if (frozen) {
+      console.log('Unfreezing');
+      await unfreeze(); // use the mutation function here
+    } else {
+      console.log('Freezing');
+      await freeze(); // use the mutation function here
+    }
+  };
+
+  return !stopAllowed ? null : (
+    <>
+      <Button
+        onClick={flipSwitch}
+        title="When freezing a world, the agents will take some time to stop what they are doing before they become frozen. "
+        imgUrl="/assets/star.svg"
+      >
+        {frozen ? 'Unfreeze' : 'Freeze'}
+      </Button>
+    </>
+  );
+}


### PR DESCRIPTION
bring back a button to stop & resume in the UI so I don't have to run CLI commands.
There's a STOP_NOT_ALLOWED env variable you can set that will hide the Freeze button entirely (e.g. in prod)