### PR TITLE
Add a per-minute cron to restart dead engines

### DIFF
--- a/convex/aiTown/game.ts
+++ b/convex/aiTown/game.ts
@@ -60,6 +60,8 @@ export class Game extends AbstractGame {
 
   pendingOperations: Array<{ name: string; args: any }> = [];
 
+  numPathfinds: number;
+
   constructor(
     engine: Doc<'engines'>,
     public worldId: Id<'worlds'>,
@@ -80,6 +82,8 @@ export class Game extends AbstractGame {
     );
 
     this.historicalLocations = new Map();
+
+    this.numPathfinds = 0;
   }
 
   static async load(
@@ -167,6 +171,7 @@ export class Game extends AbstractGame {
         new HistoricalObject(locationFields, playerLocation(player)),
       );
     }
+    this.numPathfinds = 0;
   }
 
   tick(now: number) {

--- a/convex/aiTown/player.ts
+++ b/convex/aiTown/player.ts
@@ -7,6 +7,7 @@ import {
   PATHFINDING_BACKOFF,
   HUMAN_IDLE_TOO_LONG,
   MAX_HUMAN_PLAYERS,
+  MAX_PATHFINDS_PER_STEP,
 } from '../constants';
 import { pointsEqual, pathPosition } from '../util/geometry';
 import { Game } from './game';
@@ -110,7 +111,11 @@ export class Player {
     }
 
     // Perform pathfinding if needed.
-    if (pathfinding.state.kind === 'needsPath') {
+    if (pathfinding.state.kind === 'needsPath' && game.numPathfinds < MAX_PATHFINDS_PER_STEP) {
+      game.numPathfinds++;
+      if (game.numPathfinds === MAX_PATHFINDS_PER_STEP) {
+        console.warn(`Reached max pathfinds for this step`);
+      }
       const route = findRoute(game, now, this, pathfinding.destination);
       if (route === null) {
         console.log(`Failed to route to ${JSON.stringify(pathfinding.destination)}`);

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -65,3 +65,6 @@ export const ACTIVITIES = [
 ];
 
 export const ENGINE_ACTION_DURATION = 30000;
+
+// Bound the number of pathfinding searches we do per game step.
+export const MAX_PATHFINDS_PER_STEP = 16;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -13,6 +13,8 @@ crons.interval(
   internal.world.stopInactiveWorlds,
 );
 
+crons.interval('restart dead worlds', { seconds: 60 }, internal.world.restartDeadWorlds);
+
 crons.daily('vacuum old entries', { hourUTC: 4, minuteUTC: 20 }, internal.crons.vacuumOldEntries);
 
 export default crons;


### PR DESCRIPTION
I noticed that the engine for aitown-1 was dead, and I unfortunately don't have its failure in logs. 

The engine loop can die if it hits an exception or hits a transient Convex server error, which we can't control.

Since the write to game state is predicated on the sequence number, kicking the engine is (mostly) harmless. The only exception is remembering a conversation, which does an unpredicated write.

edit: also tacked on a fix to bound the number of pathfinds done per step. I think there's a degenerate behavior in our agent logic where two agents walking towards each other can repeatedly try to pathfind to the same point. This bound mitigates the degenerate behavior (which we can properly fix separately) by pacing the number of pathfinds done per second.