### PR TITLE
Add Tunnelmole as an open source tunnelling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,27 +224,50 @@ We support using [Ollama](https://github.com/jmorganca/ollama) for conversation 
 Steps to switch to using Ollama:
 
 1. [Install Ollama](https://github.com/jmorganca/ollama#macos)
-   When Ollama runs on your laptop, it by default uses http://localhost:11434 as an endpoint for generation. Next we need to set up a ngrok tunnel so Convex can access it:
-2. [Install Ngrok](https://ngrok.com/docs/getting-started/)
+   When Ollama runs on your laptop, it by default uses http://localhost:11434 as an endpoint for generation. Next, we need to set up a tunnelmole or ngrok tunnel so Convex can access it:
+
+   **Using Tunnelmole**
+   
+   [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) is an open source tunneling tool.
+
+   You can install Tunnelmole using one of the following options:
+   - NPM:  `npm install -g tunnelmole`
+   - Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
+   - Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
+   - Windows: Install with NPM, or if you don't have NodeJS installed, download the `exe` file for Windows [here](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
+
+   Once Tunnelmole is installed, run the following command:
+
+   ```
+   tmole 11434
+   ```
+
+   Tunnelmole should output a unique url once you run this command.
+   
+   **Using Ngrok**
+   
+   Ngrok is a popular closed source tunneling tool.
+   
+   - [Install Ngrok](https://ngrok.com/docs/getting-started/)
+
    Once ngrok is installed and authenticated, run the following command:
 
-```
-ngrok http http://localhost:11434
-```
+   ```
+   ngrok http http://localhost:11434
+   ```
 
-Ngrok should output a unique url once you run this command.
+   Ngrok should output a unique url once you run this command.
 
 3. Add Ollama endpoint to Convex
 
 - run `npx convex dashboard` to bring up the convex dashboard
 - Go to Settings > Environment Variables
-- Add `OLLAMA_HOST = [your ngrok unique url from the previous step]`
+- Add `OLLAMA_HOST = [your tunnelmole/ngrok unique url from the previous step]`
 - You might also want to set:
-    `ACTION_TIMEOUT` to `100000` or more, to give your model more time to run.
-    `NUM_MEMORIES_TO_SEARCH` to `1`, to reduce the size of conversation prompts.
+   `ACTION_TIMEOUT` to `100000` or more, to give your model more time to run.
+   `NUM_MEMORIES_TO_SEARCH` to `1`, to reduce the size of conversation prompts.
 
-By default, we use `llama2-7b` model on Ollama. If you want to customize which model to use, you can set `OLLAMA_MODEL` variable under Environment Variables. Ollama model options can be found [here](https://ollama.ai/library)
-
+By default, we use `llama2-7b` model on Ollama. If you want to customize which model to use, you can set `OLLAMA_MODEL` variable under Environment Variables. Ollama model options can be found [here](https://ollama.ai/library).
 ## Credits
 
 - All interactions, background music and rendering on the <Game/> component in the project are powered by [PixiJS](https://pixijs.com/).


### PR DESCRIPTION
This PR adds [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) as a tunneling option.

Tunnelmole is a FOSS tunneling solution with a growing community. It works out of the box and can be optionally self hosted with the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service). Both the client and service are open source.

Example:
```
➜  ~ tmole 8000
http://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
https://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
```