### PR TITLE
Scroll to bottom of messages as they come in

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import PixiGame from './PixiGame.tsx';
 
 import { useElementSize } from 'usehooks-ts';
@@ -34,6 +34,8 @@ export default function Game() {
   const worldState = useQuery(api.world.worldState, worldId ? { worldId } : 'skip');
   const { historicalTime, timeManager } = useHistoricalTime(worldState?.engine);
 
+  const scrollViewRef = useRef<HTMLDivElement>(null);
+
   if (!worldId || !engineId || !game) {
     return null;
   }
@@ -64,13 +66,17 @@ https://github.com/michalochman/react-pixi-fiber/issues/145#issuecomment-5315492
           </div>
         </div>
         {/* Right column area */}
-        <div className="flex flex-col overflow-y-auto shrink-0 px-4 py-6 sm:px-6 lg:w-96 xl:pr-6 border-t-8 sm:border-t-0 sm:border-l-8 border-brown-900  bg-brown-800 text-brown-100">
+        <div
+          className="flex flex-col overflow-y-auto shrink-0 px-4 py-6 sm:px-6 lg:w-96 xl:pr-6 border-t-8 sm:border-t-0 sm:border-l-8 border-brown-900  bg-brown-800 text-brown-100"
+          ref={scrollViewRef}
+        >
           <PlayerDetails
             worldId={worldId}
             engineId={engineId}
             game={game}
             playerId={selectedElement?.id}
             setSelectedElement={setSelectedElement}
+            scrollViewRef={scrollViewRef}
           />
         </div>
       </div>

--- a/src/components/PlayerDetails.tsx
+++ b/src/components/PlayerDetails.tsx
@@ -16,12 +16,14 @@ export default function PlayerDetails({
   game,
   playerId,
   setSelectedElement,
+  scrollViewRef,
 }: {
   worldId: Id<'worlds'>;
   engineId: Id<'engines'>;
   game: ServerGame;
   playerId?: GameId<'players'>;
   setSelectedElement: SelectElement;
+  scrollViewRef: React.RefObject<HTMLDivElement>;
 }) {
   const humanTokenIdentifier = useQuery(api.world.userStatus, { worldId });
 
@@ -238,6 +240,7 @@ export default function PlayerDetails({
           inConversationWithMe={inConversationWithMe ?? false}
           conversation={{ kind: 'active', doc: playerConversation }}
           humanPlayer={humanPlayer}
+          scrollViewRef={scrollViewRef}
         />
       )}
       {!playerConversation && previousConversation && (
@@ -251,6 +254,7 @@ export default function PlayerDetails({
             inConversationWithMe={false}
             conversation={{ kind: 'archived', doc: previousConversation }}
             humanPlayer={humanPlayer}
+            scrollViewRef={scrollViewRef}
           />
         </>
       )}


### PR DESCRIPTION
This pull request modifies the messages scroll view to make it scroll automatically as the messages come in. If the scroll view isn’t already scrolled to the bottom, it won’t do anything.

https://github.com/a16z-infra/ai-town/assets/7029582/f2ff5790-76bc-487a-accc-2b286d0b103a

