### PR TITLE
Update compressPath tests

### DIFF
--- a/convex/util/geometry.test.ts
+++ b/convex/util/geometry.test.ts
@@ -11,8 +11,8 @@ describe('compressPath', () => {
       { position: { x: 0, y: 4 }, facing, t: 4 },
     ]);
     expect(compressed).toEqual([
-      { position: { x: 0, y: 0 }, facing, t: 0 },
-      { position: { x: 0, y: 4 }, facing, t: 4 },
+      [0, 0, 0, 1, 0],
+      [0, 4, 0, 1, 4],
     ]);
   });
 
@@ -27,9 +27,9 @@ describe('compressPath', () => {
       { position: { x: 2, y: 2 }, facing: facingRight, t: 4 },
     ]);
     expect(compressed).toEqual([
-      { position: { x: 0, y: 0 }, facing: facingUp, t: 0 },
-      { position: { x: 0, y: 2 }, facing: facingRight, t: 2 },
-      { position: { x: 2, y: 2 }, facing: facingRight, t: 4 },
+      [0, 0, 0, 1, 0],
+      [0, 2, 1, 0, 2],
+      [2, 2, 1, 0, 4],
     ]);
   });
 });


### PR DESCRIPTION
Looks like the `Path` type was updated in a [commit](https://github.com/a16z-infra/ai-town/commit/41985c1a2821af5a1e5ed3a2ec7a9ba82aa7f171#diff-69f9ce415e294cae239491c63cb78547b483969c299d01beb8f287a39d50cd97R17) but the `compressPath` tests weren't.

This PR fixes those tests.