### PR TITLE
Update 'Powered by Convex' link

### DIFF
--- a/src/components/PoweredByConvex.tsx
+++ b/src/components/PoweredByConvex.tsx
@@ -2,7 +2,7 @@ import bannerBg from '../../assets/convex-bg.webp';
 export default function PoweredByConvex() {
   return (
     <a
-      href="https://convex.dev"
+      href="https://convex.dev/c/ai-town"
       target="_blank"
       className="group absolute top-0 left-0 w-64 h-64 md:block z-10 hidden shape-top-left-corner overflow-hidden"
       aria-label="Powered by Convex"


### PR DESCRIPTION
Updates the 'Powered by Convex' link from https://convex.dev/ to https://convex.dev/c/ai-town. This is an AI Town-specific redirect, currently pointing to https://www.convex.dev/ai