### PR TITLE
Add canonical link

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="A virtual town where AI characters live, chat and socialize"
     />
+    <link rel="canonical" href="https://www.convex.dev/ai-town" />
     <script src="https://www.googletagmanager.com/gtag/js?id=G-BE1B7P7T72" />
     <script id="google-analytics">
       window.dataLayer = window.dataLayer || [];

--- a/src/components/PoweredByConvex.tsx
+++ b/src/components/PoweredByConvex.tsx
@@ -2,7 +2,7 @@ import bannerBg from '../../assets/convex-bg.webp';
 export default function PoweredByConvex() {
   return (
     <a
-      href="https://convex.dev"
+      href="https://convex.dev/c/ai-town"
       target="_blank"
       className="group absolute top-0 left-0 w-64 h-64 md:block z-10 hidden shape-top-left-corner overflow-hidden"
       aria-label="Powered by Convex"


### PR DESCRIPTION
Adds a canonical link, indicating to search engines that https://www.convex.dev/ai-town is the proper link for this page and to avoid indexing similar URLs.

This is to fix an issue identified in an Ahrefs report:

![image](https://github.com/a16z-infra/ai-town/assets/1382445/5b2e5263-c600-4e93-b490-51265076d240)
