### PR TITLE
Level Editor Readme and Undo (control-z) restore previous tiles

### DIFF
--- a/src/editor/README.md
+++ b/src/editor/README.md
@@ -1,0 +1,66 @@
+# Level Editor
+
+## Setup
+
+1. Run `npm run le` to start the level editor (localhost:5174)
+2. Import a map composite file (.js) into the level config input under the config tab
+3. Customize your tileset by either:
+   - Inputting it in the config tab
+   - Modifying the `DEFAULTTILESETPATH` in leconfig.js (e.g. replace `export const DEFAULTTILESETPATH = "./tilesets/gentle.png"` with your tileset path)
+
+## Map Editing Instructions
+
+### Basic Controls
+- Select tiles from the tileset in the top right pane (like selecting a paint brush)
+- Click in the top left pane to place tiles on the background level (no collision)
+- Click in the second row left pane to place tiles on the object level (with collision)
+
+### Keyboard Shortcuts
+- `f` - Fill level 0 with current tile
+- `Ctrl+z` - Undo
+- `g` - Overlay 32x32 grid
+- `s` - Generate .js file to move over to convex/maps/
+- `m` - Place semi-transparent red mask over tiles (helps find invisible tiles)
+- `d` - Hold while clicking a tile to delete
+- `p` - Toggle between 16pixel and 32 pixel
+
+## Map Composite File Structure
+
+After saving your map, you will receive a JavaScript export object similar to the following:
+
+```js
+export const tilesetpath = "./tilesets/gentle-obj.png";
+export const tiledim = 32;
+export const screenxtiles = 45;
+export const screenytiles = 32;
+export const tilesetpxw = 1440;
+export const tilesetpxh = 1024;
+
+export const bgtiles = [
+  // 2D array representing the background (no collision)
+];
+
+export const objmap = [
+  // 2D array representing the object layer (with collision)
+];
+```
+
+Explanation of each property
+- `tilesetpath`: Path to the tileset image that will be used as the “paint brushes” for your map.
+- `tiledim`: The pixel dimension of each tile (e.g., 32px).
+- `screenxtiles / screenytiles`: The map size in terms of tile columns and rows (e.g., 45 tiles wide × 32 tiles tall).
+- `tilesetpxw / tilesetpxh`: The total pixel width and height of your tileset image (not the map).
+- `bgtiles`: A 2D array storing the background layer (no collision).
+- `objmap`: A 2D array storing the object layer (with collision). Each entry is a number referencing the tile coordinate in your tileset.
+
+To use the new map go to init.js and replace the map composite file path with the new one. and clear the map table in convex with 
+
+```bash
+just convex run testing:wipeAllTables
+```
+
+and then run to restart the world
+
+```bash
+just convex run init
+```

--- a/src/editor/le.js
+++ b/src/editor/le.js
@@ -795,6 +795,11 @@ function centerCompositePane(x, y){
     compositepane.scrollTop  = y - (CONFIG.htmlCompositePaneH/2);
 }
 
+function getOldTileValue(layer, x, y) {
+    let levelIndex = level_index_from_px(x, y);
+    return layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+}
+
 function centerLayerPanes(x, y){
     // TODO remove magic number pulled from index.html
     g_ctx.g_layers.map((l) => {
@@ -941,10 +946,7 @@ function levelPlaceNoVariable(layer, e) {
     centerCompositePane(xorig, yorig);
 
     if (g_ctx.dkey || g_ctx.selected_tiles.length == 0) {
-        // Get the old value before placing new tile
-        let levelIndex = level_index_from_px(e.data.global.x, e.data.global.y);
-        let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
-        
+        let oldValue = getOldTileValue(layer, e.data.global.x, e.data.global.y);
         let ti = layer.addTileLevelPx(e.data.global.x, e.data.global.y, g_ctx.tile_index);
         UNDO.undo_add_single_index_as_task(layer, ti, oldValue);
     } else {
@@ -953,8 +955,7 @@ function levelPlaceNoVariable(layer, e) {
             // Calculate position and get old value
             let x = xorig + index[0] * g_ctx.tiledimx;
             let y = yorig + index[1] * g_ctx.tiledimx;
-            let levelIndex = level_index_from_px(x, y);
-            let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+            let oldValue = getOldTileValue(layer, x, y);
             
             let ti = layer.addTileLevelPx(x, y, index[2]);
             UNDO.undo_add_index_to_task(ti, oldValue);
@@ -1076,8 +1077,7 @@ function onLevelDragEnd(layer, e)
             for (let j = starttiley; j <= endtiley; j++) {
                 let x = i * g_ctx.tiledimx;
                 let y = j * g_ctx.tiledimx;
-                let levelIndex = level_index_from_px(x, y);
-                let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+                let oldValue = getOldTileValue(layer, x, y);
                 let ti = layer.addTileLevelPx(x, y, g_ctx.tile_index);
                 UNDO.undo_add_index_to_task(ti, oldValue);
             }
@@ -1110,8 +1110,7 @@ function onLevelDragEnd(layer, e)
                 // Get the old value before placing new tile
                 let x = i * g_ctx.tiledimx;
                 let y = j * g_ctx.tiledimx;
-                let levelIndex = level_index_from_px(x, y);
-                let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+                let oldValue = getOldTileValue(layer, x, y);
 
                 if (j === starttiley) { // first row 
                     if (i === starttilex) { // top left corner

--- a/src/editor/le.js
+++ b/src/editor/le.js
@@ -577,8 +577,37 @@ window.addEventListener(
                 if (g_ctx.debug_flag) {
                     console.log("Undo removing ", undome[i])
                 }
-                layer.container.removeChild(layer.sprites[undome[i]]);
-                g_ctx.composite.container.removeChild(layer.composite_sprites[undome[i]]);
+                // Remove current tile
+                layer.container.removeChild(layer.sprites[undome[i][0]]);
+                g_ctx.composite.container.removeChild(layer.composite_sprites[undome[i][0]]);
+                
+                // Restore original tile if it existed
+                if (undome[i][1] !== -1) {
+                    let pxloc = tileset_px_from_index(undome[i][1]);
+                    let originalTile = sprite_from_px(pxloc[0] + g_ctx.tileset.fudgex, pxloc[1] + g_ctx.tileset.fudgey);
+                    let originalTile2 = sprite_from_px(pxloc[0] + g_ctx.tileset.fudgex, pxloc[1] + g_ctx.tileset.fudgey);
+                    
+                    // Position tiles at the correct location
+                    let x = Math.floor(undome[i][0] % CONFIG.leveltilewidth) * g_ctx.tiledimx;
+                    let y = Math.floor(undome[i][0] / CONFIG.leveltilewidth) * g_ctx.tiledimx;
+                    originalTile.x = x;
+                    originalTile.y = y;
+                    originalTile2.x = x;
+                    originalTile2.y = y;
+                    originalTile2.zIndex = layer.num;
+                    
+                    // Add tiles back to containers
+                    layer.container.addChild(originalTile);
+                    g_ctx.composite.container.addChild(originalTile2);
+                    
+                    // Update sprite references
+                    layer.sprites[undome[i][0]] = originalTile;
+                    layer.composite_sprites[undome[i][0]] = originalTile2;
+                } else {
+                    // If there was no original tile, delete the sprite references
+                    delete layer.sprites[undome[i][0]];
+                    delete layer.composite_sprites[undome[i][0]];
+                }
             }
         }
         else if (event.shiftKey && event.code == 'ArrowUp') {
@@ -909,17 +938,26 @@ function levelPlaceNoVariable(layer, e) {
     let xorig = e.data.global.x;
     let yorig = e.data.global.y;
 
-    centerCompositePane(xorig,yorig);
+    centerCompositePane(xorig, yorig);
 
     if (g_ctx.dkey || g_ctx.selected_tiles.length == 0) {
+        // Get the old value before placing new tile
+        let levelIndex = level_index_from_px(e.data.global.x, e.data.global.y);
+        let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+        
         let ti = layer.addTileLevelPx(e.data.global.x, e.data.global.y, g_ctx.tile_index);
-        UNDO.undo_add_single_index_as_task(layer, ti);
+        UNDO.undo_add_single_index_as_task(layer, ti, oldValue);
     } else {
-        let undolist = [];
         UNDO.undo_mark_task_start(layer);
         for (let index of g_ctx.selected_tiles) {
-            let ti = layer.addTileLevelPx(xorig + index[0] * g_ctx.tiledimx, yorig + index[1] * g_ctx.tiledimx, index[2]);
-            UNDO.undo_add_index_to_task(ti);
+            // Calculate position and get old value
+            let x = xorig + index[0] * g_ctx.tiledimx;
+            let y = yorig + index[1] * g_ctx.tiledimx;
+            let levelIndex = level_index_from_px(x, y);
+            let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+            
+            let ti = layer.addTileLevelPx(x, y, index[2]);
+            UNDO.undo_add_index_to_task(ti, oldValue);
         }
         UNDO.undo_mark_task_end();
     }
@@ -1036,9 +1074,12 @@ function onLevelDragEnd(layer, e)
         UNDO.undo_mark_task_start(layer);
         for (let i = starttilex; i <= endtilex; i++) {
             for (let j = starttiley; j <= endtiley; j++) {
-                let squareindex = (j * g_ctx.tilesettilew) + i;
-                let ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, g_ctx.tile_index);
-                UNDO.undo_add_index_to_task(ti);
+                let x = i * g_ctx.tiledimx;
+                let y = j * g_ctx.tiledimx;
+                let levelIndex = level_index_from_px(x, y);
+                let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+                let ti = layer.addTileLevelPx(x, y, g_ctx.tile_index);
+                UNDO.undo_add_index_to_task(ti, oldValue);
             }
         }
         UNDO.undo_mark_task_end();
@@ -1066,36 +1107,41 @@ function onLevelDragEnd(layer, e)
         let ti=0;
         for (let i = starttilex; i <= endtilex; i++) {
             for (let j = starttiley; j <= endtiley; j++) {
-                let squareindex = (j * g_ctx.tilesettilew) + i;
+                // Get the old value before placing new tile
+                let x = i * g_ctx.tiledimx;
+                let y = j * g_ctx.tiledimx;
+                let levelIndex = level_index_from_px(x, y);
+                let oldValue = layer.sprites[levelIndex] ? layer.sprites[levelIndex].index : -1;
+
                 if (j === starttiley) { // first row 
                     if (i === starttilex) { // top left corner
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[0][0][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[0][0][2]);
                     }
                     else if (i == endtilex) { // top right corner
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[column - 1][0][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[column - 1][0][2]);
                     } else { // top middle
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[1][0][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[1][0][2]);
                     }
                 } else if (j === endtiley) { // last row
                     if (i === starttilex) { // bottom left corner
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[0][row][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[0][row][2]);
                     }
                     else if (i == endtilex) { // bottom right corner
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[column - 1][row][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[column - 1][row][2]);
                     } else { // bottom middle
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[1][row][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[1][row][2]);
                     }
                 } else { // middle row
                     if (i === starttilex) { // middle left 
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[0][(row > 0)? 1 : 0][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[0][(row > 0)? 1 : 0][2]);
                     }
                     else if (i === endtilex) { // middle end 
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[column - 1][(row > 0)? 1 : 0][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[column - 1][(row > 0)? 1 : 0][2]);
                     } else { // middle middle
-                        ti = layer.addTileLevelPx(i * g_ctx.tiledimx, j * g_ctx.tiledimx, selected_grid[1][(row > 0)? 1 : 0][2]);
+                        ti = layer.addTileLevelPx(x, y, selected_grid[1][(row > 0)? 1 : 0][2]);
                     }
                 }
-                UNDO.undo_add_index_to_task(ti);
+                UNDO.undo_add_index_to_task(ti, oldValue);
             }
         }
         UNDO.undo_mark_task_end();

--- a/src/editor/undo.js
+++ b/src/editor/undo.js
@@ -1,4 +1,3 @@
-
 const UNDO_STAX_MAX_LEN = 16
 
 let undo_stack = [];
@@ -9,8 +8,8 @@ export function undo_mark_task_start(layer) {
     undoqueu.push(layer);
 }
 
-export function undo_add_index_to_task(tileindex) {
-    undoqueu.push(tileindex);
+export function undo_add_index_to_task(tileindex, oldValue) {
+    undoqueu.push([tileindex, oldValue]);
 }
 
 export function undo_mark_task_end() {
@@ -21,9 +20,9 @@ export function undo_mark_task_end() {
 }
 
 // utility function for adding a single tile as a task
-export function undo_add_single_index_as_task(layer, tileindex) {
+export function undo_add_single_index_as_task(layer, tileindex, oldValue) {
     undo_mark_task_start(layer);
-    undo_add_index_to_task(tileindex);
+    undo_add_index_to_task(tileindex, oldValue);
     undo_mark_task_end();
 }
 


### PR DESCRIPTION
Change Logs:
- Added readme for level editor `src/editor/README.md`
- Updated `src/editor/undo.js` to store previous state value
- Updated `src/editor/le.js` to use the stored previous tile value and restore them when an undo is performed (works for both single click and drag tile placement)

Undo Restore previous tiles demo:
https://github.com/user-attachments/assets/d77330da-d743-4917-b0e2-d7f43d389902