### PR TITLE
Local dev & self hosting instructions revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ CONVEX_SELF_HOST_URL="http://127.0.0.1:3210"
 Then set up the Convex backend (one time):
 
 ```sh
-npx convex self-host dev --run init --until-success
+npm run predev
 ```
 
 To continuously deploy new code to the backend and print logs:
 
 ```sh
-npx convex self-host dev --tail-logs
+npm run dev:backend
 ```
 
 To see the dashboard, visit `http://localhost:6791` and provide the admin key you generated earlier.
@@ -155,7 +155,7 @@ To see the dashboard, visit `http://localhost:6791` and provide the admin key yo
 If you'll be using Ollama for local inference, you'll need to configure Docker to connect to it.
 
 ```sh
-npx convex self-host env set OLLAMA_HOST http://host.docker.internal:11434
+npx convex env set OLLAMA_HOST http://host.docker.internal:11434
 ```
 
 To test the connection (after you [have it running](#ollama-default)):

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ again and update the `.env.local` file.
 
 ```sh
 # in .env.local
-CONVEX_SELF_HOST_ADMIN_KEY="<admin-key>" # Ensure there are quotes around it
-CONVEX_SELF_HOST_URL="http://127.0.0.1:3210"
+CONVEX_SELF_HOSTED_ADMIN_KEY="<admin-key>" # Ensure there are quotes around it
+CONVEX_SELF_HOSTED_URL="http://127.0.0.1:3210"
 ```
 
 Then set up the Convex backend (one time):

--- a/fly/README.md
+++ b/fly/README.md
@@ -107,13 +107,13 @@ If you want to self-host the Convex backend on Fly.io, you can follow these step
    To deploy the AI Town functions to the backend and start the game engine:
 
    ```sh
-   npx convex self-host dev --run init --until-success
+   npx convex dev --run init --once
    ```
 
    To continuously deploy code for development:
 
    ```sh
-   npx convex self-host dev
+   npx convex dev
    ```
 
 6. Deploy the frontend app to Fly.io from the root directory. See [above](#setup) for details.

--- a/fly/README.md
+++ b/fly/README.md
@@ -98,8 +98,8 @@ If you want to self-host the Convex backend on Fly.io, you can follow these step
    following variables:
 
    ```sh
-   CONVEX_SELF_HOST_URL="<fly-backend-url>"
-   CONVEX_SELF_HOST_ADMIN_KEY="<your-admin-key>"
+   CONVEX_SELF_HOSTED_URL="<fly-backend-url>"
+   CONVEX_SELF_HOSTED_ADMIN_KEY="<your-admin-key>"
    ```
 
 5. Deploy your Convex functions to the backend using the `convex` CLI from the project root.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react": "18.2.8",
         "@types/react-dom": "18.2.4",
         "clsx": "^2.0.0",
-        "convex": "^1.19.0",
+        "convex": "^1.19.1",
         "dotenv": "^16.1.4",
         "eslint": "8.42.0",
         "hnswlib-node": "^1.4.2",
@@ -3742,9 +3742,9 @@
       "dev": true
     },
     "node_modules/convex": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.19.0.tgz",
-      "integrity": "sha512-TcglkEi392oK0Ah+zDoetFCRFXBM/lvCewi6AWfIgVCtVc9I/xdimdFOLN602V5wp7H4PN8wotpdIoixwSH7mQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.19.1.tgz",
+      "integrity": "sha512-paKFAscv5rQ36le2M9fao+hh+nhptDrkIqeiWqDBiQNe1M4EDVSDVTGmiazLcB5nbybFLOvKa2lS3DtUhkHJow==",
       "dependencies": {
         "esbuild": "0.23.0",
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/react": "18.2.8",
     "@types/react-dom": "18.2.4",
     "clsx": "^2.0.0",
-    "convex": "^1.19.0",
+    "convex": "^1.19.1",
     "dotenv": "^16.1.4",
     "eslint": "8.42.0",
     "hnswlib-node": "^1.4.2",


### PR DESCRIPTION
Instruction for developing locally with Convex, self-hosting the backend on Fly.io, or using `docker compose` locally.

Also updating the Ollama instructions & overall troubleshooting.

Will merge when the syntax is stable