### PR TITLE
feat: re-enable Clerk auth with step-by-step setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,27 +431,77 @@ If you have existing data you want to clear, you can run
 
 ### Adding Auth (Optional)
 
-You can add clerk auth back in with `git revert b44a436`. Or just look at that diff for what changed
-to remove it.
+Authentication lets users log in and join the town as a human player, enabling direct
+conversations with AI characters. This project uses [Clerk](https://clerk.com/) for auth.
 
-**Make a Clerk account**
+**Prerequisites:** The auth-enabled code lives on the `clerk-auth` branch. To enable it:
 
-- Go to https://dashboard.clerk.com/ and click on "Add Application"
-- Name your application and select the sign-in providers you would like to offer users
-- Create Application
-- Add `VITE_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` to `.env.local`
+```sh
+git cherry-pick <clerk-auth-commit>
+```
+
+Or merge the `clerk-auth` branch into your working branch.
+
+This restores Clerk integration across 5 files:
+- `convex/auth.config.js` — Convex JWT validation config
+- `convex/world.ts` — Auth-gated mutations (join, leave, chat)
+- `src/App.tsx` — Login/logout UI
+- `src/components/ConvexClientProvider.tsx` — ClerkProvider wrapper
+- `src/components/buttons/InteractButton.tsx` — Sign-in button for unauthenticated users
+
+**Step 1: Create a Clerk Application**
+
+1. Go to https://dashboard.clerk.com/ and click **"Add Application"**
+2. Name your application (e.g. "AI Town")
+3. Select the sign-in providers you want (Email, Google, GitHub, etc.)
+4. Click **"Create Application"**
+
+**Step 2: Get your API keys**
+
+From the Clerk dashboard, go to **API Keys** and copy:
+- **Publishable Key** (starts with `pk_`)
+- **Secret Key** (starts with `sk_`)
+
+Add them to your `.env.local` file:
 
 ```bash
 VITE_CLERK_PUBLISHABLE_KEY=pk_***
 CLERK_SECRET_KEY=sk_***
 ```
 
-- Go to JWT Templates and create a new Convex Template.
-- Copy the JWKS endpoint URL for use below.
+If deploying to Vercel, also add these as environment variables in your Vercel project settings.
+
+**Step 3: Create a JWT Template for Convex**
+
+1. In the Clerk dashboard, go to **JWT Templates**
+2. Click **"New template"** and select **"Convex"**
+3. Keep the default settings and click **"Save"**
+4. Copy the **Issuer URL** (looks like `https://your-app.clerk.accounts.dev/`)
+
+**Step 4: Set the Clerk Issuer URL in Convex**
 
 ```sh
-npx convex env set CLERK_ISSUER_URL # e.g. https://your-issuer-url.clerk.accounts.dev/
+# For local development
+npx convex env set CLERK_ISSUER_URL "https://your-app.clerk.accounts.dev/"
+
+# For production
+npx convex env set CLERK_ISSUER_URL "https://your-app.clerk.accounts.dev/" --prod
 ```
+
+**Step 5: Wipe and re-initialize (if you have existing data)**
+
+If you previously ran the app without auth, the existing player data uses placeholder
+identifiers. Reset the world to start fresh:
+
+```sh
+npx convex run testing:wipeAllTables
+npx convex run init
+```
+
+**Step 6: Verify**
+
+Run `npm run dev` and visit http://localhost:5173. You should see a **"Log in"** button in the
+top-right corner. After logging in, the **"Interact"** button will let you join the town.
 
 ### Deploy the frontend to Vercel
 

--- a/convex/auth.config.js
+++ b/convex/auth.config.js
@@ -1,0 +1,8 @@
+export default {
+  providers: [
+    {
+      domain: process.env.CLERK_ISSUER_URL,
+      applicationID: 'convex',
+    },
+  ],
+};

--- a/convex/world.ts
+++ b/convex/world.ts
@@ -3,7 +3,6 @@ import { internalMutation, mutation, query } from './_generated/server';
 import { characters } from '../data/characters';
 import { insertInput } from './aiTown/insertInput';
 import {
-  DEFAULT_NAME,
   ENGINE_ACTION_DURATION,
   IDLE_WORLD_TIMEOUT,
   WORLD_HEARTBEAT_INTERVAL,
@@ -99,12 +98,11 @@ export const userStatus = query({
     worldId: v.id('worlds'),
   },
   handler: async (ctx, args) => {
-    // const identity = await ctx.auth.getUserIdentity();
-    // if (!identity) {
-    //   return null;
-    // }
-    // return identity.tokenIdentifier;
-    return DEFAULT_NAME;
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return null;
+    }
+    return identity.tokenIdentifier;
   },
 });
 
@@ -113,28 +111,26 @@ export const joinWorld = mutation({
     worldId: v.id('worlds'),
   },
   handler: async (ctx, args) => {
-    // const identity = await ctx.auth.getUserIdentity();
-    // if (!identity) {
-    //   throw new ConvexError(`Not logged in`);
-    // }
-    // const name =
-    //   identity.givenName || identity.nickname || (identity.email && identity.email.split('@')[0]);
-    const name = DEFAULT_NAME;
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new ConvexError(`Not logged in`);
+    }
+    const name =
+      identity.givenName || identity.nickname || (identity.email && identity.email.split('@')[0]);
 
-    // if (!name) {
-    //   throw new ConvexError(`Missing name on ${JSON.stringify(identity)}`);
-    // }
+    if (!name) {
+      throw new ConvexError(`Missing name on ${JSON.stringify(identity)}`);
+    }
     const world = await ctx.db.get(args.worldId);
     if (!world) {
       throw new ConvexError(`Invalid world ID: ${args.worldId}`);
     }
-    // const { tokenIdentifier } = identity;
+    const { tokenIdentifier } = identity;
     return await insertInput(ctx, world._id, 'join', {
       name,
       character: characters[Math.floor(Math.random() * characters.length)].name,
-      description: `${DEFAULT_NAME} is a human player`,
-      // description: `${identity.givenName} is a human player`,
-      tokenIdentifier: DEFAULT_NAME,
+      description: `${identity.givenName} is a human player`,
+      tokenIdentifier,
     });
   },
 });
@@ -144,17 +140,16 @@ export const leaveWorld = mutation({
     worldId: v.id('worlds'),
   },
   handler: async (ctx, args) => {
-    // const identity = await ctx.auth.getUserIdentity();
-    // if (!identity) {
-    //   throw new Error(`Not logged in`);
-    // }
-    // const { tokenIdentifier } = identity;
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error(`Not logged in`);
+    }
+    const { tokenIdentifier } = identity;
     const world = await ctx.db.get(args.worldId);
     if (!world) {
       throw new Error(`Invalid world ID: ${args.worldId}`);
     }
-    // const existingPlayer = world.players.find((p) => p.human === tokenIdentifier);
-    const existingPlayer = world.players.find((p) => p.human === DEFAULT_NAME);
+    const existingPlayer = world.players.find((p) => p.human === tokenIdentifier);
     if (!existingPlayer) {
       return;
     }
@@ -171,10 +166,10 @@ export const sendWorldInput = mutation({
     args: v.any(),
   },
   handler: async (ctx, args) => {
-    // const identity = await ctx.auth.getUserIdentity();
-    // if (!identity) {
-    //   throw new Error(`Not logged in`);
-    // }
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error(`Not logged in`);
+    }
     return await engineInsertInput(ctx, args.engineId, args.name as any, args.args);
   },
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,9 @@ import a16zImg from '../assets/a16z.png';
 import convexImg from '../assets/convex.svg';
 import starImg from '../assets/star.svg';
 import helpImg from '../assets/help.svg';
-// import { UserButton } from '@clerk/clerk-react';
-// import { Authenticated, Unauthenticated } from 'convex/react';
-// import LoginButton from './components/buttons/LoginButton.tsx';
+import { UserButton } from '@clerk/clerk-react';
+import { Authenticated, Unauthenticated } from 'convex/react';
+import LoginButton from './components/buttons/LoginButton.tsx';
 import { useState } from 'react';
 import ReactModal from 'react-modal';
 import MusicButton from './components/buttons/MusicButton.tsx';
@@ -62,7 +62,7 @@ export default function Home() {
           </p>
         </div>
       </ReactModal>
-      {/*<div className="p-3 absolute top-0 right-0 z-10 text-2xl">
+      <div className="p-3 absolute top-0 right-0 z-10 text-2xl">
         <Authenticated>
           <UserButton afterSignOutUrl="/ai-town" />
         </Authenticated>
@@ -70,7 +70,7 @@ export default function Home() {
         <Unauthenticated>
           <LoginButton />
         </Unauthenticated>
-      </div> */}
+      </div>
 
       <div className="w-full lg:h-screen min-h-screen relative isolate overflow-hidden lg:p-8 shadow-2xl flex flex-col justify-start">
         <h1 className="mx-auto text-4xl p-3 sm:text-8xl lg:text-9xl font-bold font-display leading-none tracking-wide game-title w-full text-left sm:text-center sm:w-auto">
@@ -79,11 +79,11 @@ export default function Home() {
 
         <div className="max-w-xs md:max-w-xl lg:max-w-none mx-auto my-4 text-center text-base sm:text-xl md:text-2xl text-white leading-tight shadow-solid">
           A virtual town where AI characters live, chat and socialize.
-          {/* <Unauthenticated>
+          <Unauthenticated>
             <div className="my-1.5 sm:my-0" />
             Log in to join the town
             <br className="block sm:hidden" /> and the conversation!
-          </Unauthenticated> */}
+          </Unauthenticated>
         </div>
 
         <Game />

--- a/src/components/ConvexClientProvider.tsx
+++ b/src/components/ConvexClientProvider.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
-import { ConvexReactClient, ConvexProvider } from 'convex/react';
-// import { ConvexProviderWithClerk } from 'convex/react-clerk';
-// import { ClerkProvider, useAuth } from '@clerk/clerk-react';
+import { ConvexReactClient } from 'convex/react';
+import { ConvexProviderWithClerk } from 'convex/react-clerk';
+import { ClerkProvider, useAuth } from '@clerk/clerk-react';
 
 /**
  * Determines the Convex deployment to use.
@@ -21,10 +21,10 @@ const convex = new ConvexReactClient(convexUrl(), { unsavedChangesWarning: false
 
 export default function ConvexClientProvider({ children }: { children: ReactNode }) {
   return (
-    // <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string}>
-    // <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
-    <ConvexProvider client={convex}>{children}</ConvexProvider>
-    // </ConvexProviderWithClerk>
-    // </ClerkProvider>
+    <ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string}>
+      <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+        {children}
+      </ConvexProviderWithClerk>
+    </ClerkProvider>
   );
 }

--- a/src/components/buttons/InteractButton.tsx
+++ b/src/components/buttons/InteractButton.tsx
@@ -1,9 +1,9 @@
 import Button from './Button';
 import { toast } from 'react-toastify';
 import interactImg from '../../../assets/interact.svg';
-import { useConvex, useMutation, useQuery } from 'convex/react';
+import { useConvex, useConvexAuth, useMutation, useQuery } from 'convex/react';
 import { api } from '../../../convex/_generated/api';
-// import { SignInButton } from '@clerk/clerk-react';
+import { SignInButton } from '@clerk/clerk-react';
 import { ConvexError } from 'convex/values';
 import { Id } from '../../../convex/_generated/dataModel';
 import { useCallback } from 'react';
@@ -11,7 +11,7 @@ import { waitForInput } from '../../hooks/sendInput';
 import { useServerGame } from '../../hooks/serverGame';
 
 export default function InteractButton() {
-  // const { isAuthenticated } = useConvexAuth();
+  const { isAuthenticated } = useConvexAuth();
   const worldStatus = useQuery(api.world.defaultWorldStatus);
   const worldId = worldStatus?.worldId;
   const game = useServerGame(worldId);
@@ -45,11 +45,7 @@ export default function InteractButton() {
   );
 
   const joinOrLeaveGame = () => {
-    if (
-      !worldId ||
-      // || !isAuthenticated
-      game === undefined
-    ) {
+    if (!worldId || !isAuthenticated || game === undefined) {
       return;
     }
     if (isPlaying) {
@@ -60,13 +56,13 @@ export default function InteractButton() {
       void joinInput(worldId);
     }
   };
-  // if (!isAuthenticated || game === undefined) {
-  //   return (
-  //     <SignInButton>
-  //       <Button imgUrl={interactImg}>Interact</Button>
-  //     </SignInButton>
-  //   );
-  // }
+  if (!isAuthenticated || game === undefined) {
+    return (
+      <SignInButton>
+        <Button imgUrl={interactImg}>Interact</Button>
+      </SignInButton>
+    );
+  }
   return (
     <Button imgUrl={interactImg} onClick={joinOrLeaveGame}>
       {isPlaying ? 'Leave' : 'Interact'}


### PR DESCRIPTION
Cleanly restores Clerk authentication that was removed in b44a436, without requiring a conflict-prone git revert.

Changes:
- Restore convex/auth.config.js for Clerk JWT validation
- Restore auth-gated mutations in convex/world.ts
- Restore ClerkProvider in ConvexClientProvider.tsx
- Restore login UI in App.tsx and InteractButton.tsx
- Replace outdated 'git revert' README instructions with a detailed 6-step Clerk setup guide

Closes #289