### PR TITLE
Security: No server-side validation that sender belongs to target conversation/world

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -37,6 +37,63 @@ export const writeMessage = mutation({
     text: v.string(),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error('Unauthorized');
+    }
+
+    const conversation = await ctx.db.get(args.conversationId);
+    if (!conversation || conversation.worldId !== args.worldId) {
+      throw new Error('Invalid conversation');
+    }
+    const conversationRecord = conversation as {
+      playerIds?: typeof args.playerId[];
+      participants?: typeof args.playerId[];
+    };
+    const conversationPlayerIds = conversationRecord.playerIds ?? conversationRecord.participants;
+    if (!conversationPlayerIds || !conversationPlayerIds.includes(args.playerId)) {
+      throw new Error('Player is not in conversation');
+    }
+
+    const player = await ctx.db.get(args.playerId);
+    if (!player || player.worldId !== args.worldId) {
+      throw new Error('Invalid player');
+    }
+    const playerDescription = await ctx.db
+      .query('playerDescriptions')
+      .withIndex('worldId', (q) => q.eq('worldId', args.worldId).eq('playerId', args.playerId))
+      .first();
+    if (!playerDescription) {
+      throw new Error(`Invalid author ID: ${args.playerId}`);
+    }
+
+    const playerRecord = player as {
+      active?: boolean;
+      userId?: string;
+      tokenIdentifier?: string;
+    };
+    const playerDescriptionRecord = playerDescription as {
+      active?: boolean;
+      userId?: string;
+      tokenIdentifier?: string;
+    };
+    const isActive = playerDescriptionRecord.active ?? playerRecord.active;
+    if (isActive === false) {
+      throw new Error('Inactive player');
+    }
+
+    const authorizedIdentity =
+      playerRecord.userId ??
+      playerRecord.tokenIdentifier ??
+      playerDescriptionRecord.userId ??
+      playerDescriptionRecord.tokenIdentifier;
+    if (
+      !authorizedIdentity ||
+      (authorizedIdentity !== identity.subject && authorizedIdentity !== identity.tokenIdentifier)
+    ) {
+      throw new Error('Unauthorized');
+    }
+
     await ctx.db.insert('messages', {
       conversationId: args.conversationId,
       author: args.playerId,


### PR DESCRIPTION
## Problem

The `writeMessage` mutation inserts a message for arbitrary `worldId` and `conversationId` values without checking that the conversation exists in that world and that the sending player is an active participant. This enables unauthorized message injection across conversations/worlds.

**Severity**: `high`
**File**: `convex/messages.ts`

## Solution

Before inserting, load the world/conversation state and verify: (1) conversation exists in `worldId`, (2) sender is an active participant, and (3) sender is authorized user identity. Reject on any mismatch.

## Changes

- `convex/messages.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
